### PR TITLE
Setup ARM cross-compilation toolchain for MicroPython port

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,14 @@
 
 Next 5 steps for the MicroPython for Tang Nano 4K project:
 
-- [x] 1. Initialize project structure and documentation.
-- [x] 2. Research and document target hardware specifications.
-- [ ] 3. Set up MicroPython cross-compilation toolchain for the target architecture.
 - [ ] 4. Implement minimal MicroPython port with UART REPL.
 - [ ] 5. Implement basic GPIO and LED control.
+- [ ] 6. Document detailed memory map for Cortex-M3.
+- [ ] 7. Document peripheral register mapping.
+- [ ] 8. Research MicroPython core integration for GW1NSR-LV4C.
 
 ## Past Steps
+- [x] 1. Initialize project structure and documentation.
+- [x] 2. Research and document target hardware specifications.
+- [x] 3. Set up MicroPython cross-compilation toolchain for the target architecture.
 - [x] Initial setup and project organization.

--- a/documentation/TOOLCHAIN_SETUP.md
+++ b/documentation/TOOLCHAIN_SETUP.md
@@ -1,0 +1,26 @@
+# Toolchain Setup for Tang Nano 4K
+
+To cross-compile MicroPython for the ARM Cortex-M3 core on the Tang Nano 4K, the ARM GNU Toolchain is required.
+
+## Installation
+
+On Debian-based systems (like Ubuntu), the toolchain can be installed using `apt-get`:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+```
+
+## Verification
+
+To verify the installation, run the following command:
+
+```bash
+arm-none-eabi-gcc --version
+```
+
+It should output the version information of the installed GCC compiler.
+
+## Usage
+
+This toolchain provides the necessary compiler (`arm-none-eabi-gcc`), linker (`arm-none-eabi-ld`), and other utilities (like `arm-none-eabi-objcopy`) to build firmware for the ARM Cortex-M3 core integrated in the Gowin GW1NSR-LV4C FPGA.


### PR DESCRIPTION
This PR completes Step 3 of the project roadmap by setting up the ARM GNU cross-compilation toolchain required for the target Cortex-M3 core. It includes instructions for toolchain setup in 'documentation/TOOLCHAIN_SETUP.md' and updates the 'ROADMAP.md' with future project milestones (Steps 6, 7, and 8). Structure verification was performed using 'test/verify_structure.py'.

Fixes #3

---
*PR created automatically by Jules for task [3907957810874729000](https://jules.google.com/task/3907957810874729000) started by @chatelao*