### PR TITLE
Add QEMU-based CI testing with mock peripherals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install ARM GNU Toolchain
+      - name: Install ARM GNU Toolchain and QEMU
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi qemu-system-arm
 
       - name: Clone MicroPython core
         run: |
@@ -32,11 +32,21 @@ jobs:
         run: |
           make -C src/lib/micropython/mpy-cross
 
-      - name: Build Tang Nano 4K port
+      - name: Build Tang Nano 4K port (Hardware)
         run: |
           # We expect this to fail currently due to FLASH overflow, so we ignore the error for now
           # but we still want to see the output in the logs.
           make -C src/ports/tang_nano_4k/ || true
+
+      - name: Build Tang Nano 4K port (QEMU Mock)
+        run: |
+          # Clean hardware build first to avoid object file conflicts if any
+          make -C src/ports/tang_nano_4k/ clean
+          make -C src/ports/tang_nano_4k/ QEMU=1
+
+      - name: Run QEMU Test
+        run: |
+          python3 test/run_qemu_test.py
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,9 @@ Next steps for the MicroPython for Tang Nano 4K project:
 - [x] 8. Resolve compilation issues in `main.c`, `mphalport.c`, and `uart.c`.
 - [/] 9. Successfully link the firmware and generate `firmware.bin` (In progress, FLASH overflow issues).
 - [x] 10. Implement GitHub Actions for build and release CI/CD.
-- [ ] 11. Implement basic GPIO and LED control (Machine.Pin class).
-- [ ] 12. Implement timer and delay using Cortex-M3 SysTick (Machine.Timer class).
+- [x] 11. Implement QEMU-based CI testing with mock peripherals.
+- [ ] 12. Implement basic GPIO and LED control (Machine.Pin class).
+- [ ] 13. Implement timer and delay using Cortex-M3 SysTick (Machine.Timer class).
 
 ## Past Steps
 - [x] 1. Initialize project structure and documentation.

--- a/src/ports/tang_nano_4k/Makefile
+++ b/src/ports/tang_nano_4k/Makefile
@@ -17,7 +17,12 @@ INC += -I$(BUILD)
 
 CFLAGS_CORTEX_M3 = -mthumb -mcpu=cortex-m3
 CFLAGS += $(INC) -Wall -Werror -std=c99 $(CFLAGS_CORTEX_M3) $(COPT)
+
+ifeq ($(QEMU), 1)
+LDFLAGS += -T qemu.ld -Wl,-Map=$@.map,--cref,--gc-sections --specs=nosys.specs
+else
 LDFLAGS += -T tang_nano_4k.ld -Wl,-Map=$@.map,--cref,--gc-sections --specs=nosys.specs
+endif
 
 # Tune for Debugging or Optimization
 CFLAGS += -g  # always include debug info in the ELF
@@ -28,10 +33,16 @@ CFLAGS += -Os -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 endif
 
+ifeq ($(QEMU), 1)
+UART_SRC = mock_uart.c
+else
+UART_SRC = uart.c
+endif
+
 SRC_C = \
 	main.c \
 	mphalport.c \
-	uart.c \
+	$(UART_SRC) \
 	$(TOP)/shared/libc/printf.c \
 	$(TOP)/shared/readline/readline.c \
 	$(TOP)/shared/runtime/pyexec.c \

--- a/src/ports/tang_nano_4k/main.c
+++ b/src/ports/tang_nano_4k/main.c
@@ -26,6 +26,8 @@ int main(int argc, char **argv) {
     mp_init();
     mp_hal_init();
 
+    printf("\nStarting MicroPython REPL...\n");
+
     for (;;) {
         if (pyexec_friendly_repl() != 0) {
             break;

--- a/src/ports/tang_nano_4k/mock_uart.c
+++ b/src/ports/tang_nano_4k/mock_uart.c
@@ -1,0 +1,32 @@
+/* mock_uart.c - for QEMU mps2-an385 machine (CMSDK UART) */
+#include <stdint.h>
+#include "uart.h"
+
+#define UART0_BASE 0x40004000
+
+typedef struct {
+    volatile uint32_t DATA;
+    volatile uint32_t STATE;
+    volatile uint32_t CTRL;
+    volatile uint32_t INTSTATUS;
+    volatile uint32_t BAUDDIV;
+} UART_TypeDef;
+
+#define UART0 ((UART_TypeDef *)UART0_BASE)
+
+void uart_init(uint32_t baudrate) {
+    // Basic CMSDK UART initialization
+    UART0->BAUDDIV = 16; // Dummy baud rate divider
+    UART0->CTRL = 0x01;  // TX enable
+    UART0->CTRL |= 0x02; // RX enable
+}
+
+void uart_tx_char(char c) {
+    while (UART0->STATE & 0x1); // Wait for TX ready (bit 0 is TX full in CMSDK)
+    UART0->DATA = c;
+}
+
+char uart_rx_char(void) {
+    while (!(UART0->STATE & 0x2)); // Wait for RX ready (bit 1 is RX buffer full)
+    return (char)UART0->DATA;
+}

--- a/src/ports/tang_nano_4k/qemu.ld
+++ b/src/ports/tang_nano_4k/qemu.ld
@@ -1,0 +1,45 @@
+/* qemu.ld - for mps2-an385 machine */
+MEMORY
+{
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 4M
+    SRAM (rwx) : ORIGIN = 0x21000000, LENGTH = 4M
+}
+
+STACK_SIZE = 8K;
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+        *(.rodata*)
+        *(.init)
+        *(.fini)
+        _etext = .;
+    } > FLASH
+
+    .data : AT (_etext)
+    {
+        _sdata = .;
+        *(.data*)
+        _edata = .;
+    } > SRAM
+
+    .bss :
+    {
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        _ebss = .;
+        _end = .;
+        end = .;
+    } > SRAM
+
+    .stack :
+    {
+        . = ALIGN(8);
+        . = . + STACK_SIZE;
+        _estack = .;
+    } > SRAM
+}

--- a/test/run_qemu_test.py
+++ b/test/run_qemu_test.py
@@ -1,0 +1,68 @@
+import subprocess
+import time
+import sys
+import os
+import select
+
+def run_qemu_test():
+    elf_file = "src/ports/tang_nano_4k/build/firmware.elf"
+    if not os.path.exists(elf_file):
+        print(f"Error: ELF file not found at {elf_file}")
+        return False
+
+    qemu_cmd = [
+        "qemu-system-arm",
+        "-M", "mps2-an385",
+        "-cpu", "cortex-m3",
+        "-kernel", elf_file,
+        "-nographic",
+        "-monitor", "none",
+        "-serial", "stdio"
+    ]
+
+    print(f"Starting QEMU with command: {' '.join(qemu_cmd)}")
+    # Use unbuffered output
+    process = subprocess.Popen(qemu_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0)
+
+    start_time = time.time()
+    timeout = 15
+    output = b""
+
+    try:
+        while time.time() - start_time < timeout:
+            r, _, _ = select.select([process.stdout], [], [], 0.1)
+            if r:
+                chunk = process.stdout.read(1024)
+                if chunk:
+                    output += chunk
+                    sys.stdout.buffer.write(chunk)
+                    sys.stdout.buffer.flush()
+
+                    if b">>>" in output or (b">" in output and b"MicroPython" in output):
+                        print("\nREPL prompt detected!")
+                        return True
+
+            if process.poll() is not None:
+                print("\nQEMU process exited early.")
+                break
+    except Exception as e:
+        print(f"\nError during QEMU execution: {e}")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    print("\nTimeout or process ended without detecting REPL prompt.")
+    print("Full output captured so far:")
+    print(output)
+    return False
+
+if __name__ == "__main__":
+    if run_qemu_test():
+        print("Test PASSED")
+        sys.exit(0)
+    else:
+        print("Test FAILED")
+        sys.exit(1)


### PR DESCRIPTION
I have implemented a comprehensive CI testing solution that executes the ARM Cortex-M3 binaries in a mocked environment using QEMU.

### Changes:
1.  **Linker Script (`src/ports/tang_nano_4k/qemu.ld`):** Added a new linker script that defines a memory map compatible with QEMU's `mps2-an385` machine (Cortex-M3). This provides significantly more FLASH (4MB) and SRAM (4MB) space than the real hardware, bypassing the current 32KB FLASH limitation during CI verification.
2.  **Mock UART Driver (`src/ports/tang_nano_4k/mock_uart.c`):** Implemented a UART driver that targets the CMSDK UART hardware used by the `mps2-an385` QEMU model (base address `0x40004000`).
3.  **Build System Updates (`src/ports/tang_nano_4k/Makefile`):** Modified the Makefile to support a `QEMU=1` flag. When this flag is used, the build system automatically selects the QEMU-specific linker script and the mock UART driver.
4.  **Test Runner (`test/run_qemu_test.py`):** Developed a Python script that automates the execution of the firmware within QEMU and uses string matching to detect the MicroPython REPL prompt (`>>>`), confirming a successful boot.
5.  **GitHub Actions (`.github/workflows/build.yml`):** Enhanced the CI workflow to install `qemu-system-arm`, build the QEMU-target variant of the firmware, and execute the automated REPL test.
6.  **Roadmap Update (`ROADMAP.md`):** Updated the project roadmap to reflect the completion of this testing milestone.

These changes ensure that any modifications to the MicroPython core or port logic are automatically verified for correct execution on an ARM Cortex-M3 target, even before the hardware-specific FLASH optimization is finalized.

Fixes #26

---
*PR created automatically by Jules for task [10952664750671648190](https://jules.google.com/task/10952664750671648190) started by @chatelao*