### PR TITLE
Convert hardware definitions to Markdown

### DIFF
--- a/definitions/GW1NSR_DATASHEET_DS861E.md
+++ b/definitions/GW1NSR_DATASHEET_DS861E.md
@@ -1,0 +1,9274 @@
+GW1NSR Series of FPGA Products
+
+Datasheet
+
+DS861-1.8E, 06/12/2025
+
+Copyright © 2025 Guangdong Gowin Semiconductor Corporation. All Rights
+Reserved.
+, Gowin, LittleBee, and GOWINSEMI are trademarks of Guangdong Gowin
+Semiconductor Corporation and are registered in China, the U.S. Patent and Trademark
+Office, and other countries. All other words and logos identified as trademarks or service
+marks are the property of their respective holders. No part of this document may be
+reproduced or transmitted in any form or by any means, electronic, mechanical,
+photocopying, recording or otherwise, without the prior written consent of GOWINSEMI.
+Disclaimer
+GOWINSEMI assumes no liability and provides no warranty (either expressed or implied)
+and is not responsible for any damage incurred to your hardware, software, data, or
+property resulting from usage of the materials or intellectual property except as outlined in
+the GOWINSEMI Terms and Conditions of Sale. GOWINSEMI may make changes to this
+document at any time without prior notice. Anyone relying on this documentation should
+contact GOWINSEMI for the current documentation and errata.
+
+Revision History
+Date
+
+Version
+
+Description
+
+11/15/2018
+
+1.0E
+
+01/03/2019
+
+1.1E
+
+03/12/2019
+
+1.2E
+
+Initial release.
+
+Recommended operating conditions updated.
+
+Description of PSRAM reference manual updated.
+Operating temperature changed to Junction temperature.
+
+11/13/2019
+
+1.3E
+
+02/20/2020
+
+1.4E
+
+04/16/2020
+
+1.4.1E
+
+06/28/2020
+
+1.4.2E
+
+11/27/2020
+
+1.4.3E
+
+GW1NSR-4 and GW1NSR-4C added.
+ Ordering information improved.
+ DC Characteristics updated.
+ Chapter structure of AC/DC Characteristic improved.
+ Package Information updated.
+ CFU structure view updated.
+“QN48” package name of GW1NSR-2C/GW1NSR-2 corrected as
+“QN48P”.
+Maximum operating frequency of ARM Cortex-M3 updated.
+
+07/12/2021
+
+1.4.4E
+
+Description of Cortex-M3 improved.
+
+11/16/2021
+
+1.4.5E
+
+07/21/2022
+
+1.4.6E
+
+10/20/2022
+
+1.5E
+
+03/30/2023
+
+1.6E
+
+05/08/2023
+
+1.6.1E
+
+05/25/2023
+
+1.6.2E
+
+11/22/2024
+
+1.7E
+
+I/O standards and ordering information updated.
+ Recommended I/O operating conditions updated.
+ The maximum value of the differential input threshold VTHD
+updated.
+ Note about USB 2.0 PHY added.
+ Note about DC current limit added.
+ Architecture overviews of GW1NSR series of FPGA products
+updated.
+ GW1NSR-2 and GW1NSR-2C removed.
+ “Table 2-1 Output I/O Standards and Configuration Options
+Supported by GW1NSR Series of FPGA Products” updated.
+ “Table 3-8 DC Electrical Characteristics over Recommended
+Operating Conditions” updated.
+ Section 3.7.4 Byte-enable removed.
+ Description of configuration Flash added.
+ “Table 3-1 Absolute Max. Ratings” updated.
+ Information on Slew Rate removed.
+ “Table 3-24 GW1NSR-4 User Flash Parameters” updated.
+ Description added to “2.8User Flash (GW1NSR-4)”.
+ Description of true LVDS design modified.
+ Note about the default state of GPIOs modified.
+ “Table 3-3 Power Supply Ramp Rates” updated.
+ “Table 3-13 CLU Timing Parameters” updated.
+ The I/O logic output diagram and the I/O logic input diagram
+combined into “Figure 2-7 I/O Logic Input and Output”.
+ “Table 3-9 Static Current” updated.
+ “2.7.2BSRAM Configuration Modes” added.
+Information on User Flash of GW1NSR-4C removed.
+ Editorial updates.
+ Note on Maximum GPIOs added to “Table 1-1 Product
+Resources”.
+ “3.7.6 Power up Conditions” removed.
+ Note added to “Table 3-2 Recommended Operating
+Conditions”.
+ Note for “Table 3-8 DC Electrical Characteristics over
+Recommended Operating Conditions” modified.
+ “Table 3-11 Single-ended I/O DC Characteristics” updated,
+
+Date
+
+Version
+
+06/12/2025
+
+1.8E
+
+Description
+modifying IOL and IOH of LVCMOS12 standard.
+ “Table 3-15 Gearbox Timing Parameters” optimized.
+ “Table 3-24 GW1NSR-4 User Flash Parameters[1], [4], [5]”
+updated.
+ “Figure 4-5 Package Marking Examples” updated.
+ Note about default state of GPIOs optimized.
+ Description of MIPI input/output updated.
+ Description of IODELAY module updated.
+ Description of background upgrade added.
+ Description of HCLK optimized.
+ Note on functional description of dual port BSRAM and semidual port BSRAM modified.
+ Description of PSRAM updated.
+ Description of MIPI IO optimized.
+ Description of NOR Flash updated.
+ Description of Cortex-M3 updated.
+ “Table 2-1 Output I/O Standards and Configuration Options
+Supported by GW1NSR Series of FPGA Products” updated:
+correcting drive strength values for some I/O types.
+ “Table 2-2 Input I/O Standards and Configuration Options
+Supported by GW1NSR Series of FPGA Products”updated:
+modifying VCCIO values for some I/O types.
+ “Table 3-9 Static Current[1]” updated.
+ “Table 3-16 Single-ended IO Fmax” added.
+ Frequency of on-chip oscillator corrected.
+ Note for “Figure 4-5 Package Marking Examples” updated.
+
+Contents
+
+Contents
+Contents ............................................................................................................... i
+List of Figures .................................................................................................... iv
+List of Tables ....................................................................................................... v
+1 General Description......................................................................................... 1
+1.1 Features .............................................................................................................................. 1
+1.2 Product Resources ............................................................................................................. 3
+1.3 Package Information ........................................................................................................... 4
+
+2 Architecture...................................................................................................... 5
+2.1 Architecture Overview ......................................................................................................... 5
+2.2 PSRAM ............................................................................................................................... 7
+2.3 HyperRAM .......................................................................................................................... 7
+2.4 NOR FLASH ....................................................................................................................... 8
+2.5 Configurable Function Units ............................................................................................... 9
+2.6 Input/Output Blocks .......................................................................................................... 10
+2.6.1 I/O Standards..................................................................................................................11
+2.6.2 True LVDS Design ......................................................................................................... 16
+2.6.3 I/O Logic ........................................................................................................................ 16
+2.6.4 I/O Logic Modes............................................................................................................. 19
+2.7 Block SRAM...................................................................................................................... 19
+2.7.1 Introduction .................................................................................................................... 19
+2.7.2 BSRAM Configuration Modes........................................................................................ 20
+2.7.3 Mixed Data Width Configuration .................................................................................... 21
+2.7.4 Parity Bit ........................................................................................................................ 22
+2.7.5 Synchronous Operation ................................................................................................. 22
+2.7.6 BSRAM Operation Modes ............................................................................................. 22
+2.7.7 Clock Mode .................................................................................................................... 24
+2.8 User Flash (GW1NSR-4) .................................................................................................. 26
+2.9 Digital Signal Processing .................................................................................................. 26
+2.9.1 Macro ............................................................................................................................. 27
+2.9.2 DSP Operation Modes ................................................................................................... 27
+2.10 MIPI D-PHY RX/TX Implemented by Using GPIOs ........................................................ 28
+DS861-1.8E
+
+i
+
+Contents
+
+2.11 Cortex-M3 ....................................................................................................................... 28
+2.11.1 Introduction .................................................................................................................. 28
+2.11.2 Cortex-M3 .................................................................................................................... 30
+2.11.3 Bus-Matrix .................................................................................................................... 31
+2.11.4 NVIC............................................................................................................................. 31
+2.11.5 Boot Loader ................................................................................................................. 33
+2.11.6 TimeStamp ................................................................................................................... 33
+2.11.7 Timer ............................................................................................................................ 34
+2.11.8 UART ........................................................................................................................... 35
+2.11.9 Watchdog ..................................................................................................................... 37
+2.11.10 GPIO .......................................................................................................................... 39
+2.11.11 Debug Access Port..................................................................................................... 40
+2.11.12 Memory Mapping ....................................................................................................... 41
+2.11.13 Application.................................................................................................................. 41
+2.12 Clocks ............................................................................................................................. 41
+2.12.1 Global Clocks............................................................................................................... 41
+2.12.2 PLLs ............................................................................................................................. 41
+2.12.3 High-speed Clocks....................................................................................................... 42
+2.13 Long Wires...................................................................................................................... 42
+2.14 Global Set/Reset............................................................................................................. 42
+2.15 Programming & Configuration ........................................................................................ 43
+2.15.1 SRAM Configuration .................................................................................................... 43
+2.15.2 Flash Programming ..................................................................................................... 43
+2.16 On-chip Oscillator ........................................................................................................... 43
+
+3 DC and Switching Characteristics ............................................................... 45
+3.1 Operating Conditions ........................................................................................................ 45
+3.1.1 Absolute Max. Ratings ................................................................................................... 45
+3.1.2 Recommended Operating Conditions ........................................................................... 45
+3.1.3 Power Supply Ramp Rates ........................................................................................... 46
+3.1.4 Hot Socketing Specifications ......................................................................................... 46
+3.1.5 POR Specifications ........................................................................................................ 46
+3.2 ESD performance ............................................................................................................. 47
+3.3 DC Electrical Characteristics ............................................................................................ 47
+3.3.1 DC Electrical Characteristics over Recommended Operating Conditions .................... 47
+3.3.2 Static Current ................................................................................................................. 48
+3.3.3 Recommended I/O Operating Conditions ..................................................................... 49
+3.3.4 Single-ended I/O DC Characteristics............................................................................. 50
+3.3.5 Differential I/O DC Characteristics ................................................................................. 51
+3.4 Switching Characteristics ................................................................................................. 51
+
+DS861-1.8E
+
+ii
+
+Contents
+
+3.4.1 CLU Switching Characteristics ...................................................................................... 51
+3.4.2 Clock and I/O Switching Characteristics........................................................................ 52
+3.4.3 Gearbox Switching Characteristics................................................................................ 52
+3.4.4 BSRAM Switching Characteristics................................................................................. 53
+3.4.5 DSP Switching Characteristics ...................................................................................... 53
+3.4.6 On-chip Oscillator Switching Characteristics ................................................................. 53
+3.4.7 PLL Switching Characteristics ....................................................................................... 54
+3.5 Cortex-M3 AC/DC Characteristics .................................................................................... 54
+3.5.1 DC Electrical Characteristics ......................................................................................... 54
+3.5.2 AC Electrical Characteristics ......................................................................................... 54
+3.6 User Flash Characteristics(GW1NSR-4) .......................................................................... 55
+3.6.1 DC Electrical Characteristics ......................................................................................... 55
+3.6.2 AC Electrical Characteristics ......................................................................................... 56
+3.6.3 Timing Diagrams ............................................................................................................ 57
+3.7 Configuration Interface Timing Specification .................................................................... 58
+
+4 Ordering Information ..................................................................................... 59
+4.1 Part Naming ...................................................................................................................... 59
+4.2 Package Markings ............................................................................................................ 61
+
+5 About This Manual ......................................................................................... 62
+5.1 Purpose ............................................................................................................................ 62
+5.2 Related Documents .......................................................................................................... 62
+5.3 Terminology and Abbreviations ......................................................................................... 62
+5.4 Support and Feedback ..................................................................................................... 63
+
+DS861-1.8E
+
+iii
+
+List of Figures
+
+List of Figures
+Figure 2-1 Architecture Overview of GW1NSR-4 .............................................................................. 5
+Figure 2-2 Architecture Overview of GW1NSR-4C ............................................................................ 5
+Figure 2-3 CLU Structure View .......................................................................................................... 10
+Figure 2-4 IOB Structure View ........................................................................................................... 11
+Figure 2-5 I/O Bank Distribution View of GW1NSR-4C/4 .................................................................. 12
+Figure 2-6 True LVDS Design ............................................................................................................ 16
+Figure 2-7 I/O Logic Input and Output ............................................................................................... 17
+Figure 2-8 IODELAY Diagram ............................................................................................................ 18
+Figure 2-9 I/O Register Diagram ........................................................................................................ 18
+Figure 2-10 IEM Diagram................................................................................................................... 19
+Figure 2-11 Pipeline Mode in Single Port Mode, Dual Port Mode, and Semi-dual Port Mode .......... 23
+Figure 2-12 Independent Clock Mode ............................................................................................... 24
+Figure 2-13 Read/Write Clock Mode.................................................................................................. 25
+Figure 2-14 Single Port Clock Mode .................................................................................................. 25
+Figure 2-15 Cortex-M3 Architecture ................................................................................................... 30
+Figure 2-16 DEMCR Register ............................................................................................................ 34
+Figure 2-17 Timer0/Timer1 Structure View ........................................................................................ 35
+Figure 2-18 APB UART Buffering ...................................................................................................... 36
+Figure 2-19 Watchdog Operation....................................................................................................... 38
+Figure 2-20 Memory Mapping ............................................................................................................ 41
+Figure 2-21 GW1NSR-4/4C HCLK Distribution ................................................................................. 42
+Figure 3-1 Read Timing ..................................................................................................................... 57
+Figure 3-2 Program Timing ................................................................................................................ 57
+Figure 3-3 Erase Timing..................................................................................................................... 58
+Figure 4-1 Part Naming Examples for GW1NSR-4 Devices– ES...................................................... 59
+Figure 4-2 Part Naming Examples for GW1NSR-4C Devices– ES ................................................... 60
+Figure 4-3 Part Naming Examples for GW1NSR-4 Devices - Production ......................................... 60
+Figure 4-4 Part Naming Examples for GW1NSR-4C Devices - Production ...................................... 60
+Figure 4-5 Package Marking Examples ............................................................................................. 61
+
+DS861-1.8E
+
+iv
+
+List of Tables
+
+List of Tables
+Table 1-1 Product Resources............................................................................................................. 3
+Table 1-2 Package-Memory Combinations ........................................................................................ 4
+Table 1-3 Device-Package Combinations and Maximum User I/Os (True LVDS Pairs).................... 4
+Table 2-1 Output I/O Standards and Configuration Options Supported by GW1NSR Series of FPGA
+Products ............................................................................................................................................. 12
+Table 2-2 Input I/O Standards and Configuration Options Supported by GW1NSR Series of FPGA
+Products ............................................................................................................................................. 14
+Table 2-3 Port Description.................................................................................................................. 17
+Table 2-4 Total Delay of IODELAY Module ........................................................................................ 18
+Table 2-5 BSRAM Size Configuration ................................................................................................ 20
+Table 2-6 Dual Port Mixed Read/Write Data Width Configuration ..................................................... 22
+Table 2-7 Semi-dual Port Mixed Read/Write Data Width Configuration ............................................ 22
+Table 2-8 Clock Modes in Different BSRAM Modes .......................................................................... 24
+Table 2-9 List of GW1NSR series of FPGA Products that Support MIPI IO Type ............................. 28
+Table 2-10 NVIC Interrupt Vector Table ............................................................................................. 32
+Table 2-11 Timer0/ Timer1 Registers ................................................................................................. 35
+Table 2-12 UART0/ UART1 Registers ............................................................................................... 37
+Table 2-13 Watchdog Registers ......................................................................................................... 38
+Table 2-14 GPIO Registers ................................................................................................................ 39
+Table 2-15 Output Frequency Options of the On-chip Oscillator of GW1NSR-4/4C ......................... 44
+Table 3-1 Absolute Max. Ratings ....................................................................................................... 45
+Table 3-2 Recommended Operating Conditions ................................................................................ 45
+Table 3-3 Power Supply Ramp Rates ................................................................................................ 46
+Table 3-4 Hot Socketing Specifications ............................................................................................. 46
+Table 3-5 POR Parameters ................................................................................................................ 46
+Table 3-6 GW1NSR ESD - HBM ........................................................................................................ 47
+Table 3-7 GW1NSR ESD - CDM........................................................................................................ 47
+Table 3-8 DC Electrical Characteristics over Recommended Operating Conditions ......................... 47
+Table 3-9 Static Current[1]................................................................................................................... 48
+Table 3-10 Recommended I/O Operating Conditions ........................................................................ 49
+Table 3-11 Single-ended I/O DC Characteristics ............................................................................... 50
+Table 3-12 Differential I/O DC Characteristics (LVDS) ...................................................................... 51
+DS861-1.8E
+
+v
+
+List of Tables
+
+Table 3-13 CLU Timing Parameters ................................................................................................... 51
+Table 3-14 External Switching Characteristics................................................................................... 52
+Table 3-15 Gearbox Timing Parameters ............................................................................................ 52
+Table 3-16 Single-ended IO Fmax ..................................................................................................... 52
+Table 3-17 BSRAM Timing Parameters ............................................................................................. 53
+Table 3-18 DSP Timing Parameters................................................................................................... 53
+Table 3-19 On-chip Oscillator Parameters ......................................................................................... 53
+Table 3-20 PLL Parameters ............................................................................................................... 54
+Table 3-21 Current Characteristics .................................................................................................... 54
+Table 3-22 Clock Parameters............................................................................................................. 54
+Table 3-23 GW1NSR-4 User Flash DC Characteristics[1], [4] .............................................................. 55
+Table 3-24 GW1NSR-4 User Flash Parameters[1], [4], [5]...................................................................... 56
+Table 5-1 Terminology and Abbreviations .......................................................................................... 62
+
+DS861-1.8E
+
+vi
+
+1 General Description
+
+1.1 Features
+
+1
+
+General Description
+
+The GW1NSR FPGAs are members of the 1 series of the LittleBee
+family. The GW1NR devices are system-in-package chips with memory
+chips integrated into them based on the GW1NS devices. The GW1NSR
+series consists of the GW1NSR-4C device(embedded with an ARM
+Cortex-M3 processor) and the GW1NSR-4 device.
+The GW1NSR-4C device is based on the ARM Cortex-M3 processor
+and has the minimum memory required to implement system functions. Its
+adaptable and flexible embedded FPGA logic modules enable the
+implementation of diverse peripheral control tasks, along with delivering
+excellent computing capabilities and advanced exception handling.
+Seamlessly integrating a programmable logic device with an embedded
+processor, the GW1NSR-4C device is compatible with a range of
+peripheral standards, resulting in substantial cost savings for users. This
+makes it a highly versatile choice, suitable for a wide array of applications
+spanning industrial control, communications, IoT, servo drives, and
+consumer electronics, among others.
+In addition, the GW1NS series FPGA products boast high
+performance, low power consumption, a small pin count, flexible usage,
+instant-on, low-cost, non-volatility, enhanced security, and a wide range of
+packaging options.
+Gowin provides an advanced FPGA hardware development
+environment that supports FPGA synthesis, placement & routing,
+bitstream generation and download, etc.
+
+1.1 Features
+
+
+Lower power consumption
+
+
+
+55nm embedded Flash
+technology
+
+Integrated with HyperRAM/PSRAM
+memory chips
+
+
+
+Integrated with NOR Flash
+
+-
+
+Core voltage: 1.2V
+
+
+
+Hard core processor
+
+-
+
+GW1NSR-4C/4 support LV
+version only
+
+-
+
+Supports dynamically turning
+on/off the clock
+
+-
+
+DS861-1.8E
+
+-
+
+32-bit Arm Cortex-M3 processor
+
+-
+
+ARM v7-M Thumb2 architecture
+optimized for small-footprint
+embedded applications
+1(63)
+
+1 General Description
+
+-
+
+-
+
+
+
+
+
+1.1 Features
+
+System timer (SysTick), providing
+a simple, 24-bit clear-on-write,
+decrementing, wrap-on-zero
+counter with a flexible control
+mechanism
+Thumb compatible, Thumb-2
+instruction set processor core for
+high code density
+
+
+
+-
+
+NOR Flash
+
+-
+
+10,000 write cycles
+
+-
+
+Greater than 10 years of data
+retention at +85℃
+
+Multiple I/O standards
+-
+
+LVCMOS33/25/18/15/12；
+LVTTL33，SSTL33/25/18 I，
+SSTL33/25/18 II，SSTL15；
+HSTL18 I，HSTL18 II，HSTL15
+I；PCI，LVDS25，RSDS，
+LVDS25E，BLVDSE，
+MLVDSE，LVPECLE，RSDSE
+
+-
+
+GW1NSR-4C supports up to 80
+MHz operation
+
+-
+
+Hardware-division and singlecycle-multiplication
+
+-
+
+Integrated nested vectored
+interrupt controller (NVIC)
+providing deterministic interrupt
+handling
+
+-
+
+Input hysteresis options
+
+-
+
+Drive strength options
+
+-
+
+26 interrupts with eight priority
+levels
+
+-
+
+-
+
+Memory protection unit (MPU),
+providing a privileged mode for
+protecting operation system
+functionality
+
+Individual Bus Keeper, Pullup/Pull-down, and Open Drain
+options
+
+-
+
+Hot socketing
+
+-
+
+Unaligned data access, enabling
+data to be efficiently packed into
+memory
+
+-
+
+Atomic bit manipulation (bitbanding), delivering maximum
+memory utilization and
+streamlined peripheral control
+
+
+
+
+
+MIPI D-PHY RX/TX Implemented by
+Using GPIOs
+-
+
+Supports MIPI CSI-2 and MIPI
+DSI RX/TX with a data rate of up
+to 1.2Gbps per lane
+
+-
+
+Three IO types are available:
+TLVDS, ELVDS, and MIPI IO.
+
+Abundant basic logic cells
+
+-
+
+Timer0 and Timer1
+
+-
+
+4-input LUTs (LUT4s)
+
+-
+
+UART0 and UART1
+
+-
+
+Supports shift registers
+
+-
+
+watchdog
+
+-
+
+Debug port: JTAG and TPIU
+
+
+
+Block SRAMs with multiple modes
+-
+
+User Flash (GW1NSR-4)
+-
+
+NOR Flash
+
+-
+
+256Kbits storage space
+
+-
+
+Data width:32bits
+
+-
+
+10,000 write cycles
+
+-
+
+Greater than 10 years of data
+retention at +85℃
+
+Configuration Flash
+
+DS861-1.8E
+
+
+
+
+
+Supports Dual Port mode, Single
+Port mode, and Semi-Dual Port
+mode
+
+Flexible PLLs
+-
+
+Frequency adjustment
+(multiplication and division) and
+phase adjustment
+
+-
+
+Supports global clocks
+
+Built-in Flash programming
+-
+
+Instant-on
+2(63)
+
+1 General Description
+
+
+
+1.2 Product Resources
+
+-
+
+Supports security bit operation
+
+-
+
+JTAG configuration
+
+-
+
+Supports AUTO BOOT and DUAL
+BOOT
+
+-
+
+Multiple GowinCONFIG
+configuration modes: AUTO
+BOOT, DUAL BOOT, SSPI, MSPI,
+CPU, SERIAL
+
+Configuration
+
+1.2 Product Resources
+Table 1-1 Product Resources
+Device
+
+GW1NSR-4
+
+GW1NSR-4C
+
+LUT4s
+
+4,608
+
+4,608
+
+Flip-Flops (FFs)
+
+3,456
+
+3,456
+
+Block SRAM (BSRAM) Capacity (bits)
+
+180K
+
+180K
+
+Number of BSRAMs
+
+10
+
+10
+
+Multiplier (18 x 18 Multiplier)
+
+16
+
+16
+
+User Flash (bits)
+
+256K
+
+-
+
+PSRAM (bits)
+
+64M
+
+64M
+
+HyperRAM (bits)
+
+-
+
+64M
+
+NOR FLASH (bits)
+
+-
+
+32M
+
+PLLs
+
+2
+
+2
+
+OSC
+
+1, ±5% tolerance
+
+1, ±5% tolerance
+
+Hard core processor
+
+-
+
+Cortex-M3
+
+I/O Banks
+
+4
+
+4
+
+Maximum GPIOs[1]
+
+106
+
+106
+
+Core voltage
+
+1.2V
+
+1.2V
+
+Note!
+[1]
+
+This is the maximum number of GPIOs the device can provide without package
+limitation. Please refer to Table 1-3 for the maximum number of user I/Os available for the
+specific packages.
+
+DS861-1.8E
+
+3(63)
+
+1 General Description
+
+1.3 Package Information
+
+1.3 Package Information
+Table 1-2 Package-Memory Combinations
+Device
+GW1NSR-4
+
+Package
+MG64P
+MG64P
+QN48P
+QN48G
+
+GW1NSR-4C
+
+Memory Type
+PSRAM
+PSRAM
+HyperRAM
+NOR FLASH
+
+Capacity
+64Mb
+64Mb
+32Mb
+
+Width
+16 bits
+16 bits
+8 bits
+1 bit
+
+Table 1-3 Device-Package Combinations and Maximum User I/Os (True LVDS
+Pairs)
+Package
+
+Pitch (mm)
+
+Size (mm)
+
+GW1NSR-4
+
+GW1NSR-4C
+
+MG64P
+
+0.5
+
+4.2 x 4.2
+
+55(8)
+
+55(8)
+
+QN48G
+
+0.4
+
+6x6
+
+-
+
+QN48P
+
+0.4
+
+6x6
+
+-
+
+39(4)
+39(4)
+
+Note!
+
+DS861-1.8E
+
+
+
+JTAGSEL_N and JTAG pins cannot be used as GPIOs simultaneously. However,
+when mode [2:0] = 001, the JTAGSEL_N pin is always a GPIO, in other words the
+JTAGSEL_N pin and the four JTAG pins (TCK, TMS, TDI, TDO) can be used as
+GPIOs simultaneously. See UG863, GW1NSR series of FPGA Products Package
+and Pinout User Guide for more details.
+
+
+
+The package types in this manual are referred to by acronyms, see 4.1 Part Naming
+for more information.
+
+
+
+For more information, see UG864, GW1NSR-4 Pinout and UG865, GW1NSR-4C
+Pinout.
+
+4(63)
+
+2 Architecture
+
+2.1 Architecture Overview
+
+2
+
+Architecture
+
+2.1 Architecture Overview
+Figure 2-1 Architecture Overview of GW1NSR-4
+
+CLU
+Flash
+UserFlash
+PLL
+DSP
+OSC
+CLU
+BSRAM
+CLU
+CLU
+
+IOB
+
+I/OBank1
+
+I/OBank3
+
+PSRAM
+
+I/OBank0
+
+IOB
+
+IOB
+
+IOB
+
+CLU
+
+Flash
+
+IOB
+
+User Flash
+
+PLL
+
+IOB
+IOB
+
+DSP
+CLU
+
+CLU
+
+OSC
+
+CLU
+
+CLU
+
+IOB
+IOB
+
+BSRAM
+
+I/OBank2
+
+PSRAM
+
+CLU
+
+IOB
+
+IOB
+
+IOB
+
+CLU
+
+Flash
+
+IOB
+
+CLU
+
+PLL
+
+IOB
+
+Figure 2-2 Architecture Overview of GW1NSR-4C
+
+CLU
+Flash
+CLU
+PLL
+Cortex M3
+OSC
+CLU
+DSP
+BSRAM
+CLU
+I/OBank2
+
+IOB
+
+I/OBank1
+
+I/OBank3
+
+HyperRAM/PSRAM/
+NOR FLASH
+
+I/OBank0
+
+IOB
+
+IOB
+
+Cortex M3
+CLU
+
+CLU
+
+OSC
+
+IOB
+
+DSP
+
+IOB
+
+BSRAM
+
+IOB
+
+HyperRAM
+/ PSRAM/
+NOR
+FLASH
+
+The GW1NSR device is a system-in-package(SIP) chip that combines
+the GW1NS device and a memory chip. For the features and overview of
+PSRAM, see 2.2 PSRAM. For the features and overview of HyperRAM,
+see 2.3 HyperRAM. For the features and overview of NOR FLASH, see
+DS861-1.8E
+
+5(63)
+
+2 Architecture
+
+2.1 Architecture Overview
+
+2.4 NOR FLASH.
+The core of the GW1NSR device is an array of logic cells surrounded
+by IO blocks. Besides, BSRAMs, DSP blocks, PLLs, an on-chip oscillator,
+and Flash resources allowing for instant-on are provided. In addition,
+GW1NSR-4C has an embedded Cortex-M3 processor, see Table 1-1.
+The Configurable Logic Units (CLUs) are the basic logic blocks that
+form the core of GW1NSR FPGAs. Devices with different capacities have
+different numbers of rows and columns of CFUs/CLUs. For more
+information, see 2.5 Configurable Function Units.
+The I/O resources in the GW1NSR series of FPGA products are
+arranged around the periphery of the devices in groups referred to as
+banks. The I/O resources support multiple I/O standards and can be used
+for regular mode, SDR mode, and generic DDR mode. For more
+information, see 2.6 Input/Output Blocks.
+BSRAMs are arranged in row(s) inside the GW1NSR series of FPGA
+products. Each BSRAM occupies 3 CLU locations. There are two uses of
+BSRAMs, but the two uses cannot be used at the same time. Firstly, they
+function as the SRAM resources for the Cortex-M3 processor system. The
+capacity of each BSRAM is 16Kbits, and the total capacity is
+128Kbits(GW1NSR-4/4C). Secondly, they can be utilized for user storage.
+The capacity of each BSRAM is 18Kbits, and the total capacity is
+180Kbits(GW1NSR-4/4C). And in this case multiple configuration modes
+and operation modes are supported. For more information, see 2.7 Block
+SRAM.
+GW1NSR-4 has built-in User Flash memory resources, ensuring data
+retention even when powered off. See 2.8 User Flash (GW1NSR-4) for
+more information.
+The GW1NSR series of FPGA products provide DSP blocks. Each
+DSP block contains two macros, and each macro contains two pre-adders,
+two 18 x 18 bit multipliers, and one three-input ALU. For more information,
+see 2.9 Digital Signal Processing.
+The GW1NSR series of FPGA products have embedded PLL
+resources. The PLLs can provide synthesizable clock frequencies.
+Frequency adjustment (multiplication and division), phase adjustment, and
+duty cycle adjustment can be realized by configuring the parameters. In
+addition, a programmable on-chip oscillator is provided. For more
+information, see 2.12 Clocks and 2.16 On-chip Oscillator.
+The embedded configuration Flash resources in GW1NSR FPGAs
+support instant-on and security bit operations, catering to AUTO BOOT
+and DUAL BOOT configuration modes. For more information, see 2.15
+Programming & Configuration.
+The Cortex-M3 processor supports 30 MHz program loading when the
+system starts up and supports higher speed data/instructions
+transmission. The AHB expansion bus facilitates communication with
+external storage devices. The APB bus also facilitates communication with
+external devices, such as UART. GPIO interfaces are convenient for
+DS861-1.8E
+
+6(63)
+
+2 Architecture
+
+2.2 PSRAM
+
+communicating with the external interfaces. The FPGA can be
+programmed to realize controller functions across different interfaces /
+standards, such as SPI, I2C, I3C, etc. For more information, see 2.11
+Cortex-M3.
+
+2.2 PSRAM
+Features
+
+
+Clock frequency: 166 MHz
+
+
+
+Double Data Rate
+
+
+
+32Mb capacity for each PSRAM
+
+
+
+8-bit data width for each PSRAM
+
+
+
+Read-write data strobe (RWDS)
+
+
+
+Temperature compensated refresh
+
+
+
+Partial array self-refresh (PASR)
+
+
+
+Hybrid sleep mode
+
+
+
+Deep power down(DPD)
+
+
+
+Drive strengths: 35, 50, 100, and 200 Ohm
+
+
+
+Burst access
+
+
+
+Burst lengths: 16/32/64/128
+
+
+
+Status/control registers
+
+
+
+1.8V power supply
+
+Please refer to the corresponding pinout manual for the power supply
+of the PSRAM.
+The IP Core Generator integrated in the Gowin Software supports a
+PSRAM controller IP that can interface to both embedded and external
+PSRAMs. This controller IP can be used for the PSRAM power-up
+initialization, read calibration, etc. For more information, please refer to
+IPUG525，Gowin PSRAM Memory Interface IP User Guide.
+
+2.3 HyperRAM
+Features
+
+
+Clock frequency: 200 MHz
+
+
+
+Double Data Rate
+
+
+
+Clock: supports single-ended clock and differential clock
+
+
+
+Supports chip select
+
+
+
+Data width: 8bits
+
+
+
+Supports hardware reset
+
+
+
+Read-write data strobe (RWDS)
+-
+
+DS861-1.8E
+
+Bidirectional Data Strobe / Mask
+7(63)
+
+2 Architecture
+
+2.4 NOR FLASH
+
+-
+
+Output at the start of all transactions to indicate refresh latency
+
+-
+
+Output during read transactions as Read Data Strobe
+
+-
+
+Input during write transactions as Write Data Mask
+
+
+
+Die Stack Address
+
+
+
+Performance and Power
+-
+
+Configurable output drive strength
+
+-
+
+Power saving modes: Hybrid Sleep Mode and Deep Power Down
+
+Configurable Burst characteristics
+
+
+
+-
+
+Linear burst
+
+-
+
+Wrapped burst lengths: 16 bytes, 32 bytes, 64 bytes, and 128
+bytes
+
+-
+
+Hybrid burst: one wrapped burst followed by linear burst
+
+
+
+Array Refresh Modes: Full Array Refresh and Partial Array Refresh
+
+
+
+Power Supply: 1.7V~2.0V
+
+For the power supply of the HyperRAM, please refer to UG865,
+GW1NSR-4C Pinout.
+The IP Core Generator integrated in the Gowin Software supports a
+HyperRAM controller IP that can interface to both embedded and external
+HyperRAMs. This controller IP can be used for the HyperRAM power-up
+initialization, read calibration, etc. For more information, please refer to
+IPUG944, Gowin HyperRAM Memory Interface IP User Guide.
+
+2.4 NOR FLASH
+The SoC with the package suffix of “G”, such as QN48G, is
+embedded with NOR Flash.
+Features
+
+DS861-1.8E
+
+
+
+32 Mbits of storage, 256 bytes per page
+
+
+
+Supports SPI
+
+
+
+Clock frequency: 120 MHz
+
+
+
+Continuous read with 8/16/32/64 bytes wrap
+
+
+
+Software/Hardware Write Protection:
+-
+
+Entire/partial write protection via software settings
+
+-
+
+Top/bottom block protection
+
+
+
+Minimum 100,000 program/erase cycles
+
+
+
+Fast program/erase operations:
+-
+
+Page program time: 0.5ms
+
+-
+
+Sector erase time: 45ms
+
+-
+
+Block erase time: 0.15s/0.25s
+8(63)
+
+2 Architecture
+
+2.5 Configurable Function Units
+
+-
+
+Flexible Architecture:
+
+
+-
+
+Sector: 4K bytes
+
+-
+
+Block: 32/64K bytes
+
+-
+
+Erase/Program Suspend/Resume
+Lower power consumption:
+
+
+-
+
+Stand-by current: 12uA
+
+-
+
+Power down current: 1uA
+Security Features
+
+
+
+
+
+Chip erase time: 12s
+
+-
+
+128-bit unique ID for each device
+
+-
+
+3x1024-Byte security registers with OTP Lock
+Data retention: 20 years
+
+Gowin provides a universal SPI NOR Flash Interface IP allowing for
+interconnection with the SPI NOR Flash chip. For more information, see
+IPUG945, Gowin SPI Nor Flash Interface IP User Guide.
+
+2.5 Configurable Function Units
+Configurable Function Units (CFUs) and/or Configurable Logic Units
+(CLUs) are the basic cells that make up the core of Gowin FPGAs. Each
+basic cell consists of four Configurable Logic Sections (CLSs) and their
+routing resource Configurable Routing Units (CRUs), with three of the
+CLSs each containing two 4-input LUTs and two registers, and the
+remaining one only containing two 4-input LUTs, as shown in Figure 2-3.
+The CLSs in the CLUs cannot be configured as SRAMs, but can be
+configured as basic LUTs, ALUs, and ROMs. The CLSs in the CFUs can
+be configured as basic LUTs, ALUs, SRAMs, and ROMs according to
+application scenarios.
+For more information on the CFUs/CLUs, see UG288, Gowin
+Configurable Function Unit (CFU) User Guide.
+
+DS861-1.8E
+
+9(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+Figure 2-3 CLU Structure View
+Carry to Right CLU
+CLU
+
+LUT
+
+REG/
+SREG
+
+LUT
+
+REG/
+SREG
+
+LUT
+
+REG
+
+LUT
+
+REG
+
+LUT
+
+REG
+
+LUT
+
+REG
+
+LUT
+
+REG
+
+LUT
+
+REG
+
+CLS3
+
+CLS2
+
+CRU
+
+CLS1
+
+CLS0
+
+Carry from left CLU
+
+Note!
+The SREGs need special patch support. Please contact Gowin’s technical support or
+local office for this patch.
+
+2.6 Input/Output Blocks
+The Input/Output Block (IOB) in the GW1NSR series of FPGA
+products consists of a buffer pair, IO logic, and corresponding routing
+units. As shown in the figure below, each IOB connects to two pins
+(marked as A and B), which can be used as a differential pair or as two
+single-ended inputs/outputs.
+
+DS861-1.8E
+
+10(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+Figure 2-4 IOB Structure View
+Differential Pair
+
+Differential Pair
+
+“True”
+
+“Comp”
+
+“True”
+
+“Comp”
+
+PAD A
+
+PAD B
+
+PAD A
+
+PAD B
+
+Buffer Pair A & B
+
+IO Logic
+B
+CLK
+
+Routing
+Output
+Routing
+Input
+CLK
+Routing
+Output
+Routing
+Input
+
+CLK
+
+Routing
+Output
+Routing
+Input
+CLK
+Routing
+Output
+Routing
+Input
+
+Routing
+
+DI
+
+DO
+
+IO Logic
+A
+
+TO
+
+DI
+
+IO Logic
+B
+
+DO
+
+TO
+
+DI
+
+DO
+
+DI
+
+TO
+
+DO
+
+TO
+
+IO Logic
+A
+
+Buffer Pair A & B
+
+Routing
+
+The features of the IOB include:
+
+
+VCCIO supplied to each bank
+
+
+
+LVCMOS, PCI, LVTTL, LVDS, SSTL, HSTL, etc. Bank3 of GW1NSR4C/4 only supports single-ended LVCMOS input/output and LVDS25E
+differential output
+
+
+
+Input hysteresis options
+
+
+
+Drive strength options
+
+
+
+Individual Bus Keeper, Pull-up/Pull-down, and Open Drain options
+
+
+
+Hot socketing(except Bank3 of GW1NSR-4C/4)
+
+
+
+IO logic supports basic mode, SDR mode, DDR mode, etc.
+
+
+
+Bank0/Bank1 of GW1NSR-4C/4 can support MIPI input by using MIPI
+IO type.
+
+
+
+Bank2 of GW1NSR-4C/4 can support MIPI output by using MIPI IO
+type.
+
+
+
+Bank0/Bank1/Bank2 of GW1NSR-4C/4 support I3C.
+
+2.6.1~ 2.6.4 describe I/O standards, true LVDS design, I/O logic, and
+I/O logic modes. For more information about the IOB, please refer to
+UG289,Gowin Programmable IO (GPIO) User Guide.
+
+2.6.1 I/O Standards
+There are four I/O banks in the GW1NSR series of FPGA products, as
+shown in Figure 2-5. Each bank has its own I/O power supply VCCIO.
+DS861-1.8E
+
+11(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+To support SSTL, HSTL, etc., each bank also has one independent
+voltage source (VREF) as the reference voltage. You can choose to use the
+internal VREF (0.5 x VCCIO) or the external VREF input via any IO from the
+bank.
+Figure 2-5 I/O Bank Distribution View of GW1NSR-4C/4
+
+I/O Bank1
+
+I/O Bank0
+Top
+
+I/O Bank2
+
+Right
+
+GW1NSR-4C/4
+
+Bottom
+I/O Bank3
+
+The GW1NSR FPGAs support LV version.
+The GW1NSR FPGAs support 1.2V VCC (core voltage).
+VCCX(auxiliary voltage) can be set to 1.8V, 2.5V, or 3.3V, and VCCIO(I/O
+bank voltage) can be set to 1.2V, 1.5V, 1.8V, 2.5V, or 3.3V as needed.
+Note!
+
+
+For GW1NSR-4C/4, VCCIO0/VCCIO1 need to be set to 1.2V when Bank0/Bank1 are
+used for MIPI input, and VCCIO2 needs to be set to 1.2V when Bank2 is used for MIPI
+output. The MIPI speed with VCCX set to 1.8V is only 60% of the MIPI speed with
+VCCX set to 2.5V/3.3V.
+
+
+
+During configuration, all GPIOs of the device are high-impedance with internal weak
+pull-ups. After the configuration is complete, the I/O states are controlled by user
+programs and constraints. The states of configuration-related I/Os differ depending
+on the configuration mode.
+
+For the VCCIO requirements of different I/O standards, see Table 2-1
+and Table 2-2.
+Table 2-1 Output I/O Standards and Configuration Options Supported by
+GW1NSR Series of FPGA Products
+I/O Type
+(output)
+LVCMOS33/
+LVTTL33
+LVCMOS25
+
+Singleended/Differential
+
+Bank VCCIO(V)
+
+Drive Strength (mA)
+
+Single-ended
+
+3.3
+
+4/8/12/16/24
+
+Single-ended
+
+2.5
+
+4/8/12/16
+
+Universal interface
+
+LVCMOS18
+
+Single-ended
+
+1.8
+
+4/8/12
+
+Universal interface
+
+LVCMOS15
+
+Single-ended
+
+1.5
+
+4/8
+
+Universal interface
+
+DS861-1.8E
+
+Typical Applications
+Universal interface
+
+12(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+I/O Type
+(output)
+LVCMOS12
+
+Singleended/Differential
+Single-ended
+
+SSTL25_I
+
+Bank VCCIO(V)
+
+Drive Strength (mA)
+
+Typical Applications
+
+1.2
+
+4/8
+
+Universal interface
+
+Single-ended
+
+2.5
+
+8
+
+Memory interface
+
+SSTL25_II
+
+Single-ended
+
+2.5
+
+8
+
+Memory interface
+
+SSTL33_I
+
+Single-ended
+
+3.3
+
+8
+
+Memory interface
+
+SSTL33_II
+
+Single-ended
+
+3.3
+
+8
+
+Memory interface
+
+SSTL18_I
+
+Single-ended
+
+1.8
+
+8
+
+Memory interface
+
+SSTL18_II
+
+Single-ended
+
+1.8
+
+8
+
+Memory interface
+
+SSTL15
+
+Single-ended
+
+1.5
+
+8
+
+Memory interface
+
+HSTL18_I
+
+Single-ended
+
+1.8
+
+8
+
+Memory interface
+
+HSTL18_II
+
+Single-ended
+
+1.8
+
+8
+
+Memory interface
+
+HSTL15_I
+
+Single-ended
+
+1.5
+
+8
+
+Memory interface
+
+PCI33
+
+Single-ended
+
+3.3
+
+4/8
+
+LVPECL33E
+
+Differential
+
+3.3
+
+16
+
+MVLDS25E
+
+Differential
+
+2.5
+
+16
+
+BLVDS25E
+
+Differential
+
+2.5
+
+16
+
+RSDS25E
+
+Differential
+
+2.5
+
+8
+
+LVDS25E
+
+Differential
+
+2.5
+
+8
+
+MIPI
+
+Differential (MIPI)
+
+1.2
+
+3.5
+
+LVDS25
+
+Differential (True
+LVDS)
+
+2.5/3.3
+
+2/2.5/3.5/6
+
+RSDS
+
+Differential (True
+LVDS)
+
+2.5/3.3
+
+2
+
+MINILVDS
+
+Differential (True
+LVDS)
+
+2.5/3.3
+
+2
+
+2.5/3.3
+
+3.5
+
+1.5
+
+8
+
+PC and embedded
+system
+High-speed data
+transmission
+LCD timing driver
+interface and
+column driver
+interface
+Multi-point highspeed data
+transmission
+High-speed pointto-point data
+transmission
+High-speed pointto-point data
+transmission
+Mobile Industry
+Processor Interface
+High-speed pointto-point data
+transmission
+High-speed pointto-point data
+transmission
+LCD timing driver
+interface and
+column driver
+interface
+LCD row/column
+driver
+Memory interface
+
+SSTL15D
+
+Differential (True
+LVDS)
+Differential
+
+SSTL25D_I
+
+Differential
+
+2.5
+
+8
+
+Memory interface
+
+SSTL25D_II
+
+Differential
+
+2.5
+
+8
+
+Memory interface
+
+SSTL33D_I
+
+Differential
+
+3.3
+
+8
+
+Memory interface
+
+SSTL33D_II
+
+Differential
+
+3.3
+
+8
+
+Memory interface
+
+SSTL18D_I
+
+Differential
+
+1.8
+
+8
+
+Memory interface
+
+PPLVDS
+
+DS861-1.8E
+
+13(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+I/O Type
+(output)
+SSTL18D_II
+
+Singleended/Differential
+Differential
+
+HSTL18D_I
+
+Bank VCCIO(V)
+
+Drive Strength (mA)
+
+Typical Applications
+
+1.8
+
+8
+
+Memory interface
+
+Differential
+
+1.8
+
+8
+
+Memory interface
+
+HSTL18D_II
+
+Differential
+
+1.8
+
+8
+
+Memory interface
+
+HSTL15D_I
+
+Differential
+
+1.5
+
+8
+
+Memory interface
+
+LVCMOS12D
+
+Differential
+
+1.2
+
+4/8
+
+Universal interface
+
+LVCMOS15D
+
+Differential
+
+1.5
+
+4/8
+
+Universal interface
+
+LVCMOS18D
+
+Differential
+
+1.8
+
+4/8/12
+
+Universal interface
+
+LVCMOS25D
+
+Differential
+
+2.5
+
+4/8/12/16
+
+Universal interface
+
+LVCMOS33D
+
+Differential
+
+3.3
+
+4/8/12/16/24
+
+Universal interface
+
+Table 2-2 Input I/O Standards and Configuration Options Supported by GW1NSR
+Series of FPGA Products
+I/O Type (input)
+LVCMOS33/ LVTTL33
+LVCMOS25
+LVCMOS18
+LVCMOS15
+LVCMOS12
+SSTL15
+SSTL25_I
+SSTL25_II
+SSTL33_I
+SSTL33_II
+SSTL18_I
+SSTL18_II
+HSTL18_I
+HSTL18_II
+HSTL15_I
+LVCMOS33OD25
+LVCMOS33OD18
+
+DS861-1.8E
+
+Singleended/Diffe
+rential
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+
+Bank VCCIO(V)
+
+Hysteresis
+Options
+Supported?
+
+VREF Required?
+
+3.3
+
+Yes
+
+No
+
+2.5
+
+Yes
+
+No
+
+1.8
+
+Yes
+
+No
+
+1.5
+
+Yes
+
+No
+
+1.2
+
+Yes
+
+No
+
+1.5
+
+No
+
+Yes
+
+2.5
+
+No
+
+Yes
+
+2.5
+
+No
+
+Yes
+
+3.3
+
+No
+
+Yes
+
+3.3
+
+No
+
+Yes
+
+1.8
+
+No
+
+Yes
+
+1.8
+
+No
+
+Yes
+
+1.8
+
+No
+
+Yes
+
+1.8
+
+No
+
+Yes
+
+1.5
+
+No
+
+Yes
+
+2.5
+
+No
+
+No
+
+1.8
+
+No
+
+No
+
+14(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+LVDS25
+
+Singleended/Diffe
+rential
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended
+Singleended (Vref
+Input)
+Differential
+(MIPI)
+Differential
+
+RSDS
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+MINILVDS
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+PPLVDS
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+LVDS25E
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+MLVDS25E
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+BLVDS25E
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+RSDS25E
+
+Differential
+
+2.5/3.3
+
+No
+
+No
+
+LVPECL33E
+
+Differential
+
+3.3
+
+No
+
+No
+
+SSTL15D
+
+Differential
+
+1.5
+
+No
+
+No
+
+SSTL25D_I
+
+Differential
+
+2.5
+
+No
+
+No
+
+SSTL25D_II
+
+Differential
+
+2.5
+
+No
+
+No
+
+I/O Type (input)
+LVCMOS33OD15
+LVCMOS25OD18
+LVCMOS25OD15
+LVCMOS18OD15
+LVCMOS15OD12
+LVCMOS25UD33
+LVCMOS18UD25
+LVCMOS18UD33
+LVCMOS15UD18
+LVCMOS15UD25
+LVCMOS15UD33
+LVCMOS12UD15
+LVCMOS12UD18
+LVCMOS12UD25
+LVCMOS12UD33
+PCI33
+VREF1_DRIVER
+MIPI
+
+DS861-1.8E
+
+Bank VCCIO(V)
+
+Hysteresis
+Options
+Supported?
+
+VREF Required?
+
+1.5
+
+No
+
+No
+
+1.8
+
+No
+
+No
+
+1.5
+
+No
+
+No
+
+1.5
+
+No
+
+No
+
+1.2
+
+No
+
+No
+
+3.3
+
+No
+
+No
+
+2.5
+
+No
+
+No
+
+3.3
+
+No
+
+No
+
+1.8
+
+No
+
+No
+
+2.5
+
+No
+
+No
+
+3.3
+
+No
+
+No
+
+1.5
+
+No
+
+No
+
+1.8
+
+No
+
+No
+
+2.5
+
+No
+
+No
+
+3.3
+
+No
+
+No
+
+3.3
+
+Yes
+
+No
+
+1.2/1.5/1.8/2.5/3.3
+
+No
+
+Yes
+
+1.2
+
+No
+
+No
+
+2.5/3.3
+
+No
+
+No
+
+15(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+SSTL33D_I
+
+Singleended/Diffe
+rential
+Differential
+
+3.3
+
+Hysteresis
+Options
+Supported?
+No
+
+SSTL33D_II
+
+Differential
+
+3.3
+
+No
+
+No
+
+SSTL18D_I
+
+Differential
+
+1.8
+
+No
+
+No
+
+SSTL18D_II
+
+Differential
+
+1.8
+
+No
+
+No
+
+HSTL18D_I
+
+Differential
+
+1.8
+
+No
+
+No
+
+HSTL18D_II
+
+Differential
+
+1.8
+
+No
+
+No
+
+HSTL15D_I
+
+Differential
+
+1.5
+
+No
+
+No
+
+LVCMOS12D
+
+Differential
+
+1.2
+
+No
+
+No
+
+LVCMOS15D
+
+Differential
+
+1.5
+
+No
+
+No
+
+LVCMOS18D
+
+Differential
+
+1.8
+
+No
+
+No
+
+LVCMOS25D
+
+Differential
+
+2.5
+
+No
+
+No
+
+LVCMOS33D
+
+Differential
+
+3.3
+
+No
+
+No
+
+I/O Type (input)
+
+Bank VCCIO(V)
+
+VREF Required?
+No
+
+2.6.2 True LVDS Design
+Bank2 of GW1NSR-4C/4 supports true LVDS output. In addition,
+LVDS25E, MLVDS25E, BLVDS25E, etc. are supported.
+For more information about true LVDS, see UG864, GW1NSR-4
+Pinout, UG865, GW1NSR-4C Pinout.
+True LVDS input needs a 100Ω termination resistor, see Figure 2-6 for
+the reference design. Bank0/1 of the GW1NSR-4C/4 devices support
+programmable on-chip 100Ω input differential termination resistors, see
+UG289, Gowin Programmable IO User Guide.
+Figure 2-6 True LVDS Design
+Transmitter
+
+GW1NSR
+
+txout+
+txout-
+
+50Ω
+
+50Ω
+
+rxin+
+
+txout+
+
+50Ω
+
+Logic
+Array
+
+100Ω
+rxin-
+
+txout-
+
+Input IO Buffer
+
+50Ω
+
+rxin+
+
+Receiver
+
+rxin-
+
+Output IO Buffer
+
+For information about termination for LVDS25E, MLVDS25E, and
+BLVDS25E, please refer to UG289, Gowin Programmable IO User Guide.
+
+2.6.3 I/O Logic
+Figure 2-7 shows the I/O logic input and output of the GW1NSR
+series of FPGA products.
+
+DS861-1.8E
+
+16(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+Figure 2-7 I/O Logic Input and Output
+
+TX
+
+TRIREG
+GND
+SER
+
+D
+
+OREG
+
+IODELAY
+
+DI
+
+Q
+
+IREG
+
+Rate
+Sel
+
+Q0-Qn-1
+
+IDES
+
+IEM
+
+CI
+
+Table 2-3 Port Description
+Port
+
+I/O
+
+CI[1]
+
+Input
+
+DI
+
+Input
+
+Q
+
+Output
+
+Description
+GCLK input signal.
+For the number of GCLK input signals, please refer
+to UG864，GW1NSR-4 Pinout and UG865，
+GW1NSR-4C Pinout.
+IO port low-speed input signal input into the fabric
+directly.
+IREG output signal in the SDR module.
+
+Q0-Qn-1
+
+Output
+
+IDES output signal in the DDR module.
+
+Note!
+[1]
+
+When CI is used as GCLK input, DI, Q, and Q0-Qn-1 cannot be used as I/O input and
+output.
+
+Descriptions of the I/O logic modules of the GW1NSR series of FPGA
+products are presented below.
+IODELAY
+See Figure 2-8 for an overview of the IODELAY module. Each I/O of
+the GW1NSR series of FPGA products contains the IODELAY module,
+through which you can add additional delays to the I/O to adjust the delay
+of the signal. The delay time of each step is Tdlyunit, and the number of
+steps is DLYSTEP. The total delay time of IODELAY can be calculated as
+DS861-1.8E
+
+17(63)
+
+2 Architecture
+
+2.6 Input/Output Blocks
+
+follows: Ttotdly = Tdlyoffset + Tdlyunit * DLYSTEP. See Table 2-4 for the total
+delay time.
+Table 2-4 Total Delay of IODELAY Module
+
+Min.
+
+Typ.
+
+Max.
+
+Tdlyoffset
+
+450ps
+
+500ps
+
+550ps
+
+Tdlyunit
+
+-
+
+30ps
+
+-
+
+DLYSTEP
+
+0
+
+-
+
+127
+
+Figure 2-8 IODELAY Diagram
+DI
+
+DO
+DLY UNIT
+
+SDTAP
+SETN
+
+DLY ADJ
+
+DF
+
+VALUE
+
+There are two ways to control the delay:
+
+
+Static control.
+
+
+
+Dynamic control: can be used with the IEM module to adjust the
+dynamic sampling window. The IODELAY module cannot be used for
+both input and output at the same time.
+
+I/O Register
+See Figure 2-9 for the I/O register in the GW1NSR series of FPGA
+products. Each I/O provides one input register (IREG), one output register
+(OREG), and one tristate register (TRIREG).
+Figure 2-9 I/O Register Diagram
+D
+
+Q
+
+CE
+CLK
+SR
+
+Note!
+
+DS861-1.8E
+
+
+
+CE can be programmed as either active low (0: enable) or active high (1: enable).
+
+
+
+CLK can be programmed as either rising edge triggering or falling edge triggering.
+
+
+
+SR can be programmed as either synchronous/asynchronous SET/RESET or
+disabled.
+
+
+
+The register can be programmed as a register or a latch.
+
+18(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+IEM
+The IEM(Input Edge Monitor) module is used to sample data edges
+and is used in generic DDR mode, as shown in Figure 2-10.
+Figure 2-10 IEM Diagram
+CLK
+D
+
+LEAD
+IEM
+
+RESET
+
+MCLK
+LAG
+
+DES
+This series of FPGA products provide a simple deserializer(DES) for
+input I/O logic to support advanced I/O protocols.
+SER
+This series of FPGA products provide a simple serializer(SER) for
+output I/O logic to support advanced I/O protocols.
+
+2.6.4 I/O Logic Modes
+The I/O Logic of the GW1NSR series of FPGA products supports
+several operation modes. In each operation mode, the I/O (or I/O
+differential pair) can be configured as output, input, INOUT or tristate
+output (output signal with tristate control).
+
+2.7 Block SRAM
+2.7.1 Introduction
+The GW1NSR series of FPGA products provide abundant block
+SRAM resources. These memory resources are distributed as blocks
+throughout the FPGA array in the form of rows. Therefore, they are called
+block static random access memories (BSRAMs).
+BSRAMs serve two main purposes.
+1. They function as the SRAM resources for the Cortex-M3 processor
+system. The capacity of a BSRAM when used as the SRAM for
+Cortex-M3 is 16Kbits (2K-Byte). The Gowin software supports the
+configuration of SRAM resources, offering options like 2K-Byte, 4KByte, and 8K-Byte. Any unused BSRAMs are available for user
+storage.
+2. They can also be used exclusively for FPGA data storage, and each
+BSRAM can be configured to a maximum of 18,432 bits (18Kbits).
+There are four configuration modes: Single Port mode, Dual Port
+mode, Semi-Dual Port mode, and ROM mode.
+The abundant BSRAM resources are available for implementing highperformance designs. The features of BSRAMs include:
+
+DS861-1.8E
+
+
+
+Up to 18,432 bits per BSRAM
+
+
+
+Clock frequency up to 190MHz
+19(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+
+
+Supports Single Port mode
+
+
+
+Supports Dual Port mode
+
+
+
+Supports Semi-Dual Port mode
+
+
+
+Provides parity bits
+
+
+
+Supports ROM Mode
+
+
+
+Data widths from 1 to 36 bits
+
+
+
+Mixed clock mode
+
+
+
+Mixed data width mode
+
+
+
+Normal Read and Write
+
+
+
+Read-before-write
+
+
+
+Write-through
+
+For more information on the BSRAMs, see
+& SSRAM User Guide.
+
+UG285, Gowin BSRAM
+
+2.7.2 BSRAM Configuration Modes
+BSRAMs in the GW1NSR series of FPGA products support various
+data widths, see Table 2-5.
+Table 2-5 BSRAM Size Configuration
+Single Port Mode
+
+Dual Port Mode
+
+Semi-Dual Port Mode
+
+ROM Mode
+
+16K x 1
+
+16K x 1
+
+16K x 1
+
+16K x 1
+
+8K x 2
+
+8K x 2
+
+8K x 2
+
+8K x 2
+
+4K x 4
+
+4K x 4
+
+4K x 4
+
+4K x 4
+
+2K x 8
+
+2K x 8
+
+2K x 8
+
+2K x 8
+
+1K x 16
+
+1K x 16
+
+1K x 16
+
+1K x 16
+
+512 x 32
+
+-
+
+512 x 32
+
+512 x 32
+
+2K x 9
+
+2K x 9
+
+2K x 9
+
+2K x 9
+
+1K x 18
+
+1K x 18
+
+1K x 18
+
+1K x 18
+
+512 x 36
+
+-
+
+512 x 36
+
+512 x 36
+
+Single Port Mode
+The single port mode supports 2 read modes (bypass mode and
+pipeline mode) and 3 write modes (normal mode, write-through mode, and
+read-before-write mode). In single port mode, writing to or reading from
+one port is supported. During the write operation, the written data will be
+transferred to the output of the BSRAM. When the output register is
+bypassed, the new data will show up at the same write clock rising edge.
+For more information on single port mode, please refer to UG285,
+Gowin BSRAM & SSRAM User Guide.
+Dual Port Mode
+The Dual Port mode supports 2 read modes (Bypass mode and
+Pipeline mode) and 2 write modes (Normal mode and Write-through
+DS861-1.8E
+
+20(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+mode). The applicable operations are as follows:
+
+
+Two independent read operations
+
+
+
+Two independent write operations
+
+
+
+An independent read operation and an independent write operation
+
+Note!
+Performing read and write operations to the same address at the same time is not
+allowed.
+
+For more information on semi-dual port mode, please refer to UG285,
+Gowin BSRAM & SSRAM User Guide.
+Semi-Dual Port Mode
+The semi-dual port mode supports 2 read modes (Bypass mode and
+Pipeline mode) and 1 write mode (Normal mode). Semi-dual Port mode
+supports simultaneous read and write operations in the form of writing to
+port A and reading from port B.
+Note!
+Performing read and write operations to the same address at the same time is not
+allowed.
+
+For more information on semi-dual port mode, please refer to UG285,
+Gowin BSRAM & SSRAM User Guide.
+ROM Mode
+BSRAMs can be configured as ROMs. The ROM can be initialized
+during the device configuration stage, and the ROM data needs to be
+provided in the initialization file. Initialization is completed during the
+device power-on process.
+Each BSRAM can be configured as one 16Kbit ROM. For more
+information on ROM mode, please refer to UG285, Gowin BSRAM &
+SSRAM User Guide.
+
+2.7.3 Mixed Data Width Configuration
+The BSRAMs in the GW1NSR series of FPGA products support
+mixed data width operations. In dual port mode and semi-dual port mode,
+the data widths for read and write can be different, see Table 2-6 and
+Table 2-7.
+
+DS861-1.8E
+
+21(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+Table 2-6 Dual Port Mixed Read/Write Data Width Configuration
+Write Port
+
+Read Port
+
+16K x 1
+
+8K x 2
+
+4K x 4
+
+2K x 8
+
+1K x 16
+
+2K x 9
+
+1K x 18
+
+16K x 1
+
+*
+
+*
+
+*
+
+*
+
+*
+
+8K x 2
+
+*
+
+*
+
+*
+
+*
+
+*
+
+4K x 4
+
+*
+
+*
+
+*
+
+*
+
+*
+
+2K x 8
+
+*
+
+*
+
+*
+
+*
+
+*
+
+1K x 16
+
+*
+
+*
+
+*
+
+*
+
+*
+
+2K x 9
+
+*
+
+*
+
+1K x 18
+
+*
+
+*
+
+Note!
+“*” denotes the modes supported.
+
+Table 2-7 Semi-dual Port Mixed Read/Write Data Width Configuration
+Read
+Port
+
+Write Port
+16K x 1
+
+8K x 2
+
+4K x 4
+
+2K x 8
+
+1K x 16
+
+512 x 32
+
+2K x 9
+
+1K x 18
+
+512 x 36
+
+16K x 1
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+8K x 2
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+4K x 4
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+2K x 8
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+1K x 16
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+512x32
+
+*
+
+*
+
+*
+
+*
+
+*
+
+*
+
+2K x 9
+
+*
+
+*
+
+*
+
+1K x 18
+
+*
+
+*
+
+*
+
+Note!
+“*” denotes the modes supported.
+
+2.7.4 Parity Bit
+There are parity bits in BSRAMs. The 9th bit in each byte can be used
+as a parity bit to check the correctness of data transmission. It can also be
+used for data storage.
+
+2.7.5 Synchronous Operation
+
+
+All the input registers of BSRAMs support synchronous write.
+
+
+
+The output registers can be used as pipeline registers to improve
+design performance.
+
+
+
+The output registers are bypass-able.
+
+2.7.6 BSRAM Operation Modes
+The BSRAM supports five different operations, including two read
+modes (Bypass mode and Pipeline mode) and three write modes (Normal
+mode, Write-through mode, and Read-before-write mode).
+DS861-1.8E
+
+22(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+Read Mode
+The following two read modes are supported.
+PIPELINE MODE
+
+When a synchronous write cycles into a memory array with pipeline
+registers enabled, the data can be read from pipeline registers in the next
+clock cycle. The data bus can be up to 36 bits in this mode.
+BYPASS MODE
+
+When a synchronous write cycles into a memory array with pipeline
+registers bypassed, the outputs are registered at the memory array.
+Figure 2-11 Pipeline Mode in Single Port Mode, Dual Port Mode, and Semi-dual
+Port Mode
+
+AD
+
+Input
+Register
+
+DI
+WRE
+
+Memory
+Array
+
+Pipeline
+Register
+
+DO
+
+CLK
+OCE
+
+Input
+Register
+
+CLKA
+
+Input
+Register
+
+DIA
+ADA
+
+ADB
+
+Memory
+Array
+
+CLKB
+
+Pipeline
+Register
+
+OCEB
+
+DOB
+
+DIA
+ADA
+
+WREA
+
+DIB
+
+Input
+Register
+
+Input
+Register
+Memory
+Array
+
+CLKA
+
+OCEA
+
+ADB
+WREB
+
+CLKB
+
+Pipeline
+Register
+
+Pipeline
+Register
+
+DOA
+
+DOB
+
+OCEB
+
+Write Mode
+NORMAL MODE
+
+In this mode, when you write data to one port, the output data of this
+port does not change. The written data will not appear at the read port.
+DS861-1.8E
+
+23(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+WRITE-THROUGH MODE
+
+In this mode, when you write data to one port, the written data will
+appear at the output of this port.
+READ-BEFORE-WRITE MODE
+
+In this mode, when you write data to one port, the written data will be
+stored in the memory according to the address, and the original data in
+this address will appear at the output of this port.
+
+2.7.7 Clock Mode
+Table 2-8 lists the clock modes in different BSRAM modes:
+Table 2-8 Clock Modes in Different BSRAM Modes
+Clock Mode
+Independent
+Mode
+Read/Write
+Mode
+Single Port
+Mode
+
+Clock
+Clock
+Clock
+
+Dual Port Mode
+
+Semi-Dual Port Mode
+
+Single Port Mode
+
+Yes
+
+No
+
+No
+
+Yes
+
+Yes
+
+No
+
+No
+
+No
+
+Yes
+
+Independent Clock Mode
+Figure 2-12 shows the independent clocking operations in dual port
+mode with one clock at each port. CLKA controls all the registers at Port A;
+CLKB controls all the registers at Port B.
+Figure 2-12 Independent Clock Mode
+WREA
+
+WREB
+
+Input
+Register
+
+Input
+Register
+
+ADA
+DIA
+
+ADB
+
+Memory
+Array
+
+CLKA
+DOA
+
+DIB
+
+CLKB
+
+Output
+Register
+
+Output
+Register
+
+WREA
+
+WREB
+
+DOB
+
+Read/Write Clock Mode
+Figure 2-13 shows the read/write clocking operations in semi-dual
+port mode with one clock at each port. The write clock (CLKA) controls
+data inputs, write addresses and read/write enable signals of Port A. The
+read clock (CLKB) controls data outputs, read addresses, and read enable
+signals of Port B.
+
+DS861-1.8E
+
+24(63)
+
+2 Architecture
+
+2.7 Block SRAM
+
+Figure 2-13 Read/Write Clock Mode
+Input
+Register
+CLKA
+
+Input
+Register
+
+Memory
+Array
+
+CLKB
+
+Pipeline
+Register
+
+Single Port Clock Mode
+Figure 2-14 shows the clocking operation in single port mode.
+Figure 2-14 Single Port Clock Mode
+WRE
+
+DI
+
+AD
+
+Input
+Register
+Memory
+Array
+
+CLK
+
+DO
+
+Output
+Register
+
+WRE
+
+DS861-1.8E
+
+25(63)
+
+2 Architecture
+
+2.8 User Flash (GW1NSR-4)
+
+2.8 User Flash (GW1NSR-4)
+The capacity of the User Flash in GW1NSR-4 is 32KB. The User
+Flash consists of row memories and column memories. One row memory
+consists of 64 column memories. The capacity of one column memory is
+32 bits, and the capacity of one row memory is 64*32=2048 bits. Page
+erase is supported, and the capacity of one page is 2048 bytes, that is,
+one page contains 8 rows. The key features include:
+
+
+NOR Flash
+
+
+
+10,000 write cycles
+
+
+
+Greater than 10 years of data retention at +85℃
+
+
+
+Data width: 32 bits
+
+
+
+Capacity: 128 rows x 64 columns x 32 = 256 Kbits
+
+
+
+Page erase capability: 2,048 bytes per page
+
+
+
+Fast Page Erase/Word Program Operation
+
+
+
+Clock frequency: 40 MHz
+
+
+
+Word Program Time: ≤16μs
+
+
+
+Page Erase Time: ≤120 ms
+
+
+
+Current
+-
+
+Read current/duration: 2.19mA/25ns (VCC) & 0.5mA/25ns
+(VCCX)(MAX)
+
+-
+
+Program/erase operation: 12/12mA(MAX)
+
+For more information about the User Flash in GW1NSR-4, please
+refer to UG295, Gowin User Flash User Guide. For the correspondence
+between User Flash primitives and devices supported, please refer to
+Table 3-1 Devices Supported of UG295, Gowin User Flash User Guide.
+
+2.9 Digital Signal Processing
+GW1NSR-4C/4 provide abundant DSP resources. Gowin’s DSP
+solutions can address high-performance digital signal processing needs
+such as FIR and FFT designs. The DSP resources have the advantages of
+stable timing performance, high resource utilization, and low power
+consumption.
+The DSP resources offer the following functions:
+
+DS861-1.8E
+
+
+
+Multipliers with three widths: 9-bit, 18-bit, 36-bit
+
+
+
+54-bit ALU
+
+
+
+Multipliers cascading to support wider data widths
+
+
+
+Barrel shifters
+
+
+
+Adaptive filtering through signal feedback
+
+
+
+Computing with options to round to a positive number or a prime
+26(63)
+
+2 Architecture
+
+2.9 Digital Signal Processing
+
+number
+
+
+Supports pipeline mode and bypass mode.
+
+2.9.1 Macro
+The DSP blocks are distributed throughout the FPGA array in the form
+of rows. Each DSP block contains two macros, and each macro contains
+two pre-adders, two 18 x 18 bit multipliers, and one three-input ALU.
+Pre-adder
+Each DSP macro contains two pre-adders for implementing preaddition, pre-subtraction, and shifting.
+The pre-adders are located at the first stage and have two input ports:
+
+
+Parallel 18-bit input B or SBI;
+
+
+
+Parallel 18-bit input A or SIA.
+
+Note!
+Each input port supports pipeline mode and bypass mode.
+
+Gowin’s pre-adders can be used independently as function blocks,
+which support 9-bit and 18-bit widths.
+Multiplier
+The multipliers are located after the pre-adders. The multipliers can
+be configured as 9 x 9, 18 x 18, 36 x 18, or 36 x 36. Register mode and
+bypass mode are supported in both input and output ports. The
+configuration modes that a macro supports include:
+
+
+One 18 x 36 multiplier
+
+
+
+Two 18 x 18 multipliers
+
+
+
+Four 9 x 9 multipliers
+
+Note!
+Two macros can form one 36 x 36 multiplier.
+
+Arithmetic Logic Unit
+Each DSP macro contains one 54-bit ALU, which can further enhance
+multipliers’ functions. Register mode and bypass mode are supported in
+both input and output ports. The functions include:
+
+
+Addition/subtraction operations of multiplier output data/0, data A, and
+data B.
+
+
+
+Addition/subtraction operations of multiplier output data/0, data B, and
+carry C.
+
+
+
+Addition/subtraction operations of data A, data B, and carry C.
+
+2.9.2 DSP Operation Modes
+
+DS861-1.8E
+
+
+
+Multiplier mode
+
+
+
+Multiply accumulator mode
+27(63)
+
+2 Architecture
+
+2.10 MIPI D-PHY RX/TX Implemented by Using GPIOs
+
+
+
+Multiply-add accumulator mode
+
+For more information on the DSP resources, see UG287, Gowin
+Digital Signal Processing (DSP) User Guide.
+
+2.10 MIPI D-PHY RX/TX Implemented by Using GPIOs
+When implementing soft MIPI D-PHY RX/TX with GPIOs, three IO
+types are available: TLVDS, ELVDS, and MIPI IO.
+All GW1NSR FPGAs support the TLVDS/ELVDS types. To implement
+MIPI D-PHY with the TLVDS/ELVDS types, you need to emulate MIPI HS
+and MIPI LP by using LVDS25(E)+LVCMOS12 and need to add external
+resistors.
+Some GW1NSR FPGAs support the MIPI IO type. The MIPI IO has
+an internal resistor network and supports automatic switching between HS
+and LP. The support list of the MIPI IO type is shown in Table 2-9.
+For information on IO type selection and off-chip termination, please
+refer to “4 Functional Description” in IPUG948, Gowin MIPI D-PHY RX TX
+Advance User Guide.
+Table 2-9 List of GW1NSR series of FPGA Products that Support MIPI IO Type
+MIPI Input/Output
+
+GW1NSR-4
+
+GW1NSR-4C
+
+MIPI Input
+
+Bank0/1
+
+Bank0/1
+
+MIPI Output
+
+Bank2
+
+Bank2
+
+The key features of the soft MIPI D-PHY RX/TX include:
+
+
+
+MIPI Alliance Standard for D-PHY Specification, Version 1.2
+High Speed RX and TX at up to 4.8Gbps
+Supports up to 4 data lanes and 1 clock lane
+Supports multiple PHYs(if there are enough IOs available)
+Supports bidirectional low-power (LP) mode
+Supports MIPI DSI and MIPI CSI-2 link layers
+Supports built-in HS Sync, bit and lane alignment
+Supports MIPI D-PHY RX 1:8 and 1:16 deserialization modes
+Supports IO Types of ELVDS, TLVDS, MIPI IO, etc.
+
+
+
+Bank0/Bank1/Bank2 of GW1NSR-4C/4 support I3C
+
+
+
+
+
+
+
+
+
+
+For more information, see IPUG948, Gowin MIPI D-PHY RX TX
+Advance User Guide.
+
+2.11 Cortex-M3
+2.11.1 Introduction
+GW1NSR-4C is a system-on-chip FPGA device that incorporates a
+microprocessor system hard core, Gowin FPGA fabric, and other standard
+peripherals and hard cores, including BSRAM resources and PLL/OSC
+clocking resources. The embedded microprocessor system contains a
+DS861-1.8E
+
+28(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+low-power, low-cost and high-performance ARM Cortex-M3 32-bit RISC
+core. The flexible FPGA fabric serves as user programmable peripherals,
+or soft-core IPs.
+The embedded microprocessor system consists of a processor block
+and an associated bus system that connects to standard peripherals. The
+FPGA fabric contains rich programmable logic resources offering a flexible
+architecture that allows the user to achieve multiple peripherals by calling
+soft-core IPs, such as SPI, I2C. The microprocessor system only interfaces
+with the FPGA fabric and JTAG config-core internally with no access to the
+I/O blocks of GW1NSR-4C.
+The bus system consists of an AHB-Lite Bus, an AHB2APB bridge
+bus, and two APB buses(APB1 and APB2).
+The microprocessor system accesses the FPGA sub-memory system
+through the AHB bus. The system includes a controller that implements
+read-only operations of 32KB of Flash resources and read/write operations
+of a maximum of 16KB of BSRAM resources. Upon Power-On boot
+loading, Cortex-M3 loads instructions and data that are pre-stored in the
+Flash-ROM before initiating the execution.
+In addition, there are two AHB bus extension ports: INTEXP0 and
+TARGEXP0. Each of these AHB extension ports provides a 128-bit AHB
+bus interconnecting to any high-speed User programmable peripherals
+implemented within the FPGA. A GPIO block interconnects the AHB bus
+with the FPGA fabric to allow the user to implement general purpose I/O
+functions in the FPGA.
+In terms of the two APB Bus (APB1 and APB2), APB1 interconnects
+with two timers (Timer0 and Timer1), two UARTs (Uart0 and Uart1), and
+one watchdog. The two UARTs connect to the FPGA directly. The two
+timers and the watchdog are controlled and used within the
+microprocessor system and are accessed through registers. The APB2
+bus connects directly to the FPGA.
+The processor block consists of a Cortex-M3 core, bus matrix, Nested
+Vector Interrupt Controller (NVIC), Debug Access Port (DAP), and time
+stamp, etc.
+The Cortex-M3 core accesses the bus system through the bus matrix.
+Six user interrupts are supported. The DAP contains the JTAG DAP
+and the Trace-Port-Interface-Unit (TPIU).
+The microprocessor system also provides an interrupt monitor signal,
+which combines GPIO interrupts as well as APB1 peripherals (UART0,
+UART1, Timer0, Timer1, Watchdog) interrupts, back to the FPGA fabric to
+report the current run-time interrupt status of the microprocessor system.
+FPGA fabric takes advantage of its rich Clocking Resource (PLL, OSC)
+and provides the Main Clock, Power-On Reset and System Reset signals
+to the embedded microprocessor system.
+See Figure 2-15 for the Cortex-M3 architecture.
+
+DS861-1.8E
+
+29(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Figure 2-15 Cortex-M3 Architecture
+
+Cortex-M3
+Processor Block
+JTAG I/F
+
+DAP
+
+Cortex-M3
+Core
+
+Time
+Stamp
+Bus-Matrix
+
+TPIU I/F
+User_int0/1
+
+NVIC
+
+Clk/Reset
+AHB Extension:
+INTEXP0
+AHB Extension:
+TARGEXP0
+AHB To
+SRAM/FLASH I/F
+
+AHB
+Lite
+Bus
+
+JTAG
+
+Clock
+Resource
+PLL/OSC
+Memory Sub-System
+Mem-Cntrl
+B-SRAM
+
+GPIO I/F
+
+GPIO
+
+FLASH
+
+AHB2APB
+
+IntMonitor
+Logic Resource
+Soft-Core
+
+APB1
+
+APB I/F
+
+SPI
+
+I2C
+
+UART1
+
+UART
+I/F
+
+I3C
+
+USB
+Type-C
+
+UART0
+
+UART
+I/F
+
+APB2
+
+Timer0
+
+Others
+
+Timer1
+Watchdog
+
+2.11.2 Cortex-M3
+Features
+
+DS861-1.8E
+
+
+
+Compact core
+
+
+
+Thumb-2 instruction set, delivering the high-performance expected of
+an ARM core
+
+
+
+Associated with 32 bits and 16 bits devices; typically, in the range of a
+few kilobytes of memory for microcontroller class applications
+
+
+
+Rapid application execution through Harvard architecture
+characterized by separate buses for instructions and data
+
+
+
+Exception and Interrupt handling, implemented through register
+operations
+
+
+
+Deterministic, fast interrupt processing
+
+
+
+Memory protection unit (MPU), providing a privileged mode for
+protecting operation system functionality
+30(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+
+
+Migration from the ARM7 processor family for better performance and
+power efficiency
+
+
+
+Full-featured debug solution
+-
+
+JTAG Debug Port
+
+-
+
+Flash Patch and Breakpoint (FPB) unit for implementing
+breakpoints
+
+-
+
+Data Watchpoint and Trigger (DWT) unit for implementing
+watchpoints, trigger resources, and system profiling
+
+-
+
+Instrumentation Trace Macrocell (ITM) for printf style debugging
+
+-
+
+Trace Port Interface Unit (TPIU) for bridging to a Trace Port
+
+2.11.3 Bus-Matrix
+The bus-matrix is used to connect the Cortex-M3 processor and
+debug port with an external AHB bus. Connections between the busmatrix and the AHB bus:
+
+
+ICode bus: 32bit AHBLite bus, used for fetching instructions and
+vectors from code space.
+
+
+
+DCode bus: 32bit AHBLite bus, used for data loading/storage and
+debug access.
+
+
+
+System bus: 32bit AHBLite bus, used for fetching instructions and
+vectors from system space, data loading/storage and debug access.
+
+
+
+APB: 32bit APB bus, used for external space data loading/storage and
+debug access.
+
+The bus-matrix also controls the following functions.
+
+
+Unaligned accesses: converts the unaligned processor access to
+aligned access.
+
+
+
+Bit-banding: converts the alias access of Bit_band to Bit_band space
+access.
+
+
+
+Write buffer: the bus-matrix contains one write-buffer, ensuring that the
+processor core is not affected by bus delay.
+
+2.11.4 NVIC
+The features of NVIC include:
+
+DS861-1.8E
+
+
+
+Supports up to 26 interrupts
+
+
+
+Supports 6 user interrupts
+
+
+
+A programmable priority level of 0-7 for each interrupt. A higher level
+corresponds to a lower priority; as such level 0 is the highest interrupt
+priority
+
+
+
+Level and pulse detection of interrupt signals
+
+
+
+Dynamic reprioritization of interrupts
+
+
+
+The processor automatically stacks its state on exception entry and
+31(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+unstacks this state on exception exit, with no instruction overhead
+Table 2-10 NVIC Interrupt Vector Table
+Address
+
+Name
+
+0x00000000
+
+_StackTop
+
+0x00000004
+
+Reset_Handler
+
+0x00000008
+
+NMI_Handler
+
+0x0000000C
+
+HardFault_Handler
+
+0x00000010
+
+MemMange_Handler
+
+0x00000014
+
+BusFault_Handler
+
+0x00000018
+
+UsageFault_Handler
+
+0x0000002C
+
+SVC_Handler
+
+0x00000030
+
+DebugMon_Handler
+
+0x00000038
+
+PendSV_Handler
+
+0x0000003C
+
+SysTick_Handler
+
+Type
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read/Wr
+ite
+Read
+only
+Read/Wr
+ite
+Read
+only
+Read/
+Write/
+Read
+only
+Read/Wr
+ite
+
+Description
+
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+
+UART0 receive and transmit
+interrupt
+
+Top of interrupt stack
+Reset interrupt
+NMI interrupt
+Hard fault interrupt
+MPU fault interrupt
+Bus fault interrupt
+Usage fault interrupt
+SVCall interrupt
+Debug monitor interrupt
+Pending interrupt
+System timer interrupt
+
+External interrupt
+0x00000040
+
+UART0_Handler
+
+0x00000044
+
+USER_INT0_Handler
+
+0x00000048
+
+UART1_Handler
+
+0x0000004C
+
+USER_INT1_Handler
+
+0x00000050
+
+USER_INT2_Handler
+
+0x00000058
+
+PORT0_COMB_Handler
+
+0x0000005C
+
+USER_INT3_Handler
+
+0x00000060
+
+TIMER0_Handler
+
+0x00000064
+
+TIMER1_Handler
+
+0x0000006C
+
+I2C_Handler
+
+0x00000070
+
+UARTOVF_Handler
+
+0x00000074
+
+USER_INT4_Handler
+
+0x00000078
+
+USER_INT5_Handler
+
+DS861-1.8E
+
+User interrupt 0
+UART1 receive and transmit
+interrupt
+User interrupt 1
+User interrupt 2
+GPIO0 interrupt
+User interrupt 3
+TIMER0 interrupt
+TIMER1 interrupt
+I2C interrupt
+UART0/UART1
+interrupt
+
+overflow
+
+User interrupt 4
+User interrupt 5
+
+32(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Address
+
+Name
+
+0x00000080
+
+PORT0_0_Handler
+
+0x00000084
+
+PORT0_1_Handler
+
+0x00000088
+
+PORT0_2_Handler
+
+0x0000008C
+
+PORT0_3_Handler
+
+0x00000090
+
+PORT0_4_Handler
+
+0x00000094
+
+PORT0_5_Handler
+
+0x00000098
+
+PORT0_6_Handler
+
+0x0000009C
+
+PORT0_7_Handler
+
+0x000000A0
+
+PORT0_8_Handler
+
+0x000000A4
+
+PORT0_9_Handler
+
+0x000000A8
+
+PORT0_10_Handler
+
+0x000000AC
+
+PORT0_11_Handler
+
+0x000000B0
+
+PORT0_12_Handler
+
+0x000000B4
+
+PORT0_13_Handler
+
+0x000000B8
+
+PORT0_14_Handler
+
+0x000000BC
+
+PORT0_15_Handler
+
+Type
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+Read/Wr
+ite
+
+Description
+GPIO0 pin0 interrupt
+GPIO0 pin1 interrupt
+GPIO0 pin2 interrupt
+GPIO0 pin3 interrupt
+GPIO0 pin4 interrupt
+GPIO0 pin5 interrupt
+GPIO0 pin6 interrupt
+GPIO0 pin7 interrupt
+GPIO0 pin8 interrupt
+GPIO0 pin9 interrupt
+GPIO0 pin10 interrupt
+GPIO0 pin11 interrupt
+GPIO0 pin12 interrupt
+GPIO0 pin13 interrupt
+GPIO0 pin14 interrupt
+GPIO0 pin15 interrupt
+
+2.11.5 Boot Loader
+The boot loader loads the initial stack pointer value from the program
+memory, and branches to the reset handler that the reset vector specifies
+in the program memory.
+The current boot loader is based on UART Message Monitor which is
+easy to interface as a communication port with PC host. Below is an
+example of how to deploy the boot loader:
+
+
+Power-on reset to enter the reset handler to call the boot loader.
+
+
+
+Set UART0 registers, such as BAUDIV and CTRL, to configure the
+appropriate baud rate for transmission and reception.
+
+
+
+Begin Flash loader subroutine execution such as memory test, timer0,
+and timer1 tests etc.
+
+
+
+Write a 0x4 character (EOP) to terminate the program.
+
+2.11.6 TimeStamp
+A 48-bit timestamp counter is included in the ITM. It is clock gated and
+DS861-1.8E
+
+33(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+enabled by the Trace Enable (TRCENA) bit of DEMCR (Debug Exception
+and monitor control register), which is a global enable bit that enables both
+the Data Watch Trace (DWT) and Instrumentation Trace Module (ITM) on
+behalf of the debug of the Cortex-M3 microprocessor. The time stamp
+generator is used during the debug process to set up the break point and
+marching step, etc.
+Figure 2-16 DEMCR Register
+DEMCR寄存器
+25 24 23
+
+31
+Reserved
+TRCENA
+
+20 19 18 17 16 15
+
+11 10 9 8 7 6 5 4 3
+
+Reserved
+
+Reserved
+
+MON_REQ
+MON_STEP
+MON_PEND
+MON_EN
+
+VC_HARDERR
+VC_INTERR
+VC_BUSERR
+VC_STATERR
+VC_CHKERR
+VC_NOCPERR
+VC_MMERR
+Reserved
+VC_CORERESET
+
+1 0
+
+Note!
+TRCENA is the global enable for DWT and ITM:
+
+
+0: DWT and ITM units disabled.
+
+
+
+1: DWT and ITM units enabled.
+
+2.11.7 Timer
+GW1NSR-4C offers an embedded microprocessor system that
+contains two synchronous standard timers: Timer0 and Timer1. These can
+be accessed and controlled through the APB1 bus.
+Timer0 and Timer1 are 32-bit down-counters with the following
+features:
+
+DS861-1.8E
+
+
+
+Users can generate an interrupt request signal, TIMERINT, when the
+counter reaches 0. The interrupt request is held until it is cleared by
+writing to the INTCLEAR Register.
+
+
+
+Users can employ the zero-to-one transition of the external input
+signal, EXTIN, as a timer enable.
+
+
+
+If the timer count reaches 0 and, at the same time, the software clears
+a previous interrupt status, the interrupt status is set to 1.
+
+
+
+The external clock, EXTIN, must be slower than half of the peripheral
+clock because it is sampled by a double flip-flop before going through
+edge-detection logic when the external inputs act as a clock.
+
+
+
+Timer0: EXTIN is hard-wired to GPIO[1].
+
+
+
+Timer1: EXTIN is hard-wired to GPIO[6].
+
+34(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Figure 2-17 Timer0/Timer1 Structure View
+PCLK
+
+Reload value
+
+Synchronizer
+
+Edge detection
+
+PCLKG
+CTRL[2]
+PRESETn
+
+Decrement
+
+PSEL
+
+32bits down
+counter
+
+PADDR[11:2]
+
+EXTIN
+
+1
+
+0
+
+1
+CTRL[1]
+1
+
+PENABLE
+CTRL[0]
+
+PWRITE
+
+0
+PWDATA[31:0]
+
+1
+
+SET
+
+PREADY
+
+Val==1
+
+PSLVERR
+
+TIMERINT
+
+CTRL[3]
+CLR
+
+PRDATA[31:0]
+ECOREVNUM[3:0]
+
+The Timer0/Timer1 registers are shown in the following table. The
+base address of Timer0 is 0x40000000 and the base address of Timer1 is
+0x40001000.
+Table 2-11 Timer0/ Timer1 Registers
+Name
+
+Base Offset
+
+Type
+
+CTRL
+
+0x000
+
+Read/
+Write
+
+VALUE
+
+0x004
+
+RELOAD
+
+0x008
+
+INTSTATUS/
+INTCLEAR
+
+0x00C
+
+Read/
+Write
+Read/
+Write
+Read/
+Write
+
+Widt
+h
+
+Reset Value
+
+Description
+
+4
+
+0x0
+
+[3]: System timer interrupt enable
+[2]: Select external input as clock
+[1]: Select external input as enable
+[0]: Enable
+
+32
+
+0x00000000
+
+Current value
+
+32
+
+0x00000000
+
+Reload value. Write to this register
+to set the current value.
+
+1
+
+0x0
+
+[0]: Timer interrupt. Write 1 to clear.
+
+2.11.8 UART
+The microprocessor system of GW1NSR-4C is embedded with two
+UARTs: UART0 and UART1. These can be accessed and controlled
+through the APB1 bus. The max. baud rate supported is 921.6Kbits/s.
+UART0 and UART1support 8 bits communication without parity and
+one stop bit.
+
+DS861-1.8E
+
+35(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Figure 2-18 APB UART Buffering
+You can write a new character to the write buffer
+while the shift register is sending out a character
+
+Write buffer
+
+Shift register
+
+TXD
+
+TX FSM
+
+APB
+interface
+
+Baud rate
+generator
+
+RX FSM
+
+Read buffer
+
+Shift register
+
+RXD
+
+The shift register can receive the next character
+while the data in the receive buffer is waiting for
+the processor to read it
+
+UART0 and UART support a high-speed test mode. When CTRL[6] is
+set to 1, the serial data is transmitted at one bit per clock cycle. This
+enables you to send text messages in a much shorter simulation time. The
+APB interface always sends an “OK” response with no wait state. You
+must program the baud rate divider register BAUDDIV before enabling the
+UART.
+The BAUDTICK output pulses at a frequency of 16 times that of the
+programmed baud rate. You can use this external signal for capturing
+UART data in a synchronous environment. The TXEN output signal
+indicates the status of CTRL[0]. You can use this signal to switch a
+bidirectional I/O pin in a silicon device to UART data output mode
+automatically when the UART transmission feature is enabled.
+The buffer overrun status in the STATE field is used to drive the
+overrun interrupt signals. Therefore, clearing the buffer overrun status deasserts the overrun interrupt, and clearing the overrun interrupt bit also
+clears the buffer overrun status bit in the STATE field.
+The UART0/UART1 registers are shown in the following table. The
+base address of UART0 is 0X40004000 and the base address of UART1
+is 0X40005000.
+
+DS861-1.8E
+
+36(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Table 2-12 UART0/ UART1 Registers
+Name
+
+Base Offset
+
+Type
+
+Widt
+h
+
+Reset Value
+
+DATA
+
+0x000
+
+Read/
+Write
+
+8
+
+0x--
+
+STATE
+
+0x004
+
+Read/
+Write
+
+4
+
+0x0
+
+CTRL
+
+0x008
+
+Read/
+Write
+
+7
+
+0x00
+
+INTSTATUS/
+INTCLEAR
+
+0x00C
+
+Read/
+Write
+
+4
+
+0x0
+
+BAUDDIV
+
+0x010
+
+Read/
+Write
+
+20
+
+0x00000
+
+Description
+8-bit data
+Read: received data.
+Write: transmited data.
+[3]: RX buffer overrun, write 1 to
+clear.
+[2]: TX buffer overrun, write 1 to
+clear.
+[1]: RX buffer full, read-only.
+[0]: TX buffer full, read-only.
+[6]：High-speed test mode for TX
+only.
+[5]：RX overrun interrupt enable.
+[4]：TX overrun interrupt enable.
+[3]：RX interrupt enable.
+[2]：TX interrupt enable.
+[1]：RX enable.
+[0]：TX enable.
+[3]：RX overrun interrupt, write 1 to
+clear.
+[2]：TX overrun interrupt, write 1 to
+clear.
+[1]：RX interrupt, write 1 to clear.
+[0]：TX interrupt, write 1 to clear.
+[19:0]: Baud rate divider. The
+minimum number is 16.
+
+2.11.9 Watchdog
+The microprocessor system of GW1NSR-4C is embedded with a
+watchdog, which can be accessed and controlled through the APB1 bus.
+The watchdog module is based on a 32-bit down-counter that is
+initialized from the reload register, WDOGLOAD.
+The watchdog module generates a regular interrupt, WDOGINT,
+depending on a programmed value. The counter decrements by one on
+each positive clock edge of WDOGCLK when the clock enable,
+WDOGCLKEN, is active high. The watchdog monitors the interrupt and
+asserts a reset request WDOGRES signal when the counter reaches 0,
+and the counter is stopped. On the next enabled WDOGCLK clock edge,
+the counter is reloaded from the WDOGLOAD register and the countdown
+sequence continues.
+The watchdog module applies a reset to a system in the event of a
+software failure, providing a way to recover from software crashes. For
+example, if the interrupt is not cleared and the counter reaches 0 again,
+the watchdog module triggers a system reset.
+The Watchdog operation is shown in the following figure.
+
+DS861-1.8E
+
+37(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Figure 2-19 Watchdog Operation
+Count down
+without
+reprogram
+Watchdog is
+programmed
+
+Counter reloaded
+and count down
+without reprogram
+Counter reaches
+zero
+
+Counter reaches
+zero
+
+If the INTEN bit in the
+WDOGCONTROL register is set
+to 1, WDOGINT is asserted
+
+If the RESEN bit in the
+WDOGCONTROL register is set
+to 1, WDOGRES is asserted
+
+The watchdog registers are shown in the following table. The
+watchdog base address is 0x40008000.
+Table 2-13 Watchdog Registers
+Name
+
+Base
+Offset
+
+WDOGLOAD
+
+0x00
+
+WDOGVALUE
+
+0x04
+
+WDOGCONTROL
+
+0x08
+
+WDOGINTCLR
+
+0x0C
+
+WDOGRIS
+
+0x10
+
+WDOGMIS
+
+0x14
+
+WDOGLOCK
+
+0xC00
+
+WDOGTCR
+
+0xF00
+
+WDOGTOP
+
+0xF04
+
+WDOGPERIPHID4
+
+0XFD0
+
+WDOGPERIPHID5
+
+0XFD4
+
+WDOGPERIPHID6
+
+0XFD8
+
+WDOGPERIPHID7
+
+0XFDC
+
+WDOGPERIPHID0
+
+0XFE0
+
+WDOGPERIPHID1
+
+0XFE4
+
+WDOGPERIPHID2
+
+0XFE8
+
+WDOGPERIPHID3
+
+0XFEC
+
+DS861-1.8E
+
+Type
+Read/
+Write
+Read
+only
+Read/
+Write
+Write
+only
+Read
+only
+Read
+only
+Read/
+Write
+Read/
+Write
+Write
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+
+Width
+
+Reset Value
+
+Description
+
+32
+
+0xFFFFFFFF
+
+Watchdog Load Register
+
+32
+
+0xFFFFFFFF
+
+Watchdog Value Register
+
+2
+
+0x0
+
+-
+
+0x-
+
+1
+
+0x0
+
+1
+
+0x0
+
+32
+
+0x0
+
+1
+
+0x0
+
+2
+
+0x0
+
+8
+
+0x04
+
+Peripheral ID Register 4
+
+8
+
+0x00
+
+Peripheral ID Register 5
+
+8
+
+0x00
+
+Peripheral ID Register 6
+
+8
+
+0x00
+
+Peripheral ID Register 7
+
+8
+
+0x24
+
+Peripheral ID Register 0
+
+8
+
+0XB8
+
+Peripheral ID Register 1
+
+8
+
+0X1B
+
+Peripheral ID Register 2
+
+8
+
+0X00
+
+Peripheral ID Register 3
+
+Watchdog Control Register
+[1]：
+[0]：
+Watchdog
+Interrupt
+Clear
+Register
+Watchdog Raw Interrupt Status
+Register
+Watchdog
+Interrupt
+Status
+Register
+Watchdog Lock Register
+Watchdog
+Integration
+Test
+Control Register
+Watchdog Integration Test Output
+Set Register
+
+38(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Name
+
+Base
+Offset
+
+WDOGPCELLID0
+
+0XFF0
+
+WDOGPCELLID1
+
+0XFF4
+
+WDOGPCELLID2
+
+0XFF8
+
+WDOGPCELLID3
+
+0XFFC
+
+Type
+Read
+only
+Read
+only
+Read
+only
+Read
+only
+
+Width
+
+Reset Value
+
+Description
+
+8
+
+0X0D
+
+Component ID Register 0
+
+8
+
+0XF0
+
+Component ID Register 1
+
+8
+
+0X05
+
+Component ID Register 2
+
+8
+
+0XB1
+
+Component ID Register 3
+
+2.11.10 GPIO
+The microprocessor system of GW1NSR-4C communicates with the
+GPIO block through the AHB bus. The GIPO block interconnects with the
+FPGA. The GPIO block provides a 16-bit I/O interface with the following
+features:
+
+
+Programmable interrupt generation capability. You can configure each
+bit of the I/O pins to generate interrupts.
+
+
+
+Bit masking supports the use of address values.
+
+
+
+Registers for alternate function switching with pin multiplexing support.
+
+
+
+Thread safe operation by providing separate set and clear addresses
+for control registers.
+
+The GPIO registers are shown in the following table. The base
+address of GPIO is 0x40010000.
+Table 2-14 GPIO Registers
+Name
+
+Base
+Offset
+
+DATA
+
+0x0000
+
+DATAOUT
+
+0x0004
+
+Type
+Read/
+Write
+Read/
+Write
+
+Widt
+h
+
+Reset Value
+
+Description
+
+16
+
+0x----
+
+Data value [15:0]
+
+16
+
+0x0000
+
+Data output register value [15:0]
+
+OUTENSET
+
+0x0010
+
+Read/
+Write
+
+16
+
+0x0000
+
+Output enable set [15:0]
+Write 1: Sets the output enable
+bit.
+Write 0: No effect.
+Read 1: Indicates the signal
+direction as output.
+Read 0: Indicates the signal
+direction as input.
+
+OUTENCLR
+
+0x0014
+
+Read/
+Write
+
+16
+
+0x0000
+
+Output enable clear [15:0]
+
+ALTFUNCSET
+
+0x0018
+
+Read/
+Write
+
+16
+
+0x0000
+
+Alternative function set [15:0]
+Write 1: Sets the ALTFUNC bit.
+Write 0: No effect.
+Read 0: GPIO as I/O
+Read 1: ALTFUNC Function
+
+ALTFUNCCLR
+
+0x001C
+
+Read/
+Write
+
+16
+
+0x0000
+
+Alternative function clear [15:0]
+
+INTENSET
+
+0x0020
+
+Read/
+Write
+
+16
+
+0x0000
+
+Interrupt enable set [15:0]
+Write 1: Sets the enable bit.
+Write 0: No effect.
+
+DS861-1.8E
+
+39(63)
+
+2 Architecture
+
+2.11 Cortex-M3
+
+Base
+Offset
+
+Name
+
+INTENCLR
+
+0x0024
+
+INTTYPESET
+
+0x0028
+
+INTTYPECLR
+
+0x002C
+
+INTPOLSET
+
+0x0030
+
+INTPOLCLR
+
+0x0034
+
+INTSTATUS/
+INTCLEAR
+
+0x0038
+
+MASKLOWBYTE
+MASKHIGHBYTE
+Reserved
+
+0x04000x07FC
+0x08000x0BFC
+0x0C000x0FCF
+
+Type
+
+Read/
+Write
+Read/
+Write
+Read/
+Write
+Read/
+Write
+Read/
+Write
+Read/
+Write
+Read/
+Write
+Read/
+Write
+–
+
+Widt
+h
+
+Reset Value
+
+Description
+Read 0: Interrupt disabled.
+Read 1: Interrupt enabled.
+Interrupt enable clear [15:0]
+Write 1: Clears the enable bit.
+Write 0: No effect.
+Read 0: Interrupt disabled.
+Read 1: Interrupt enabled.
+
+16
+
+0x0000
+
+16
+
+0x0000
+
+Interrupt type set [15:0]
+
+16
+
+0x0000
+
+Interrupt type clear [15:0]
+
+16
+
+0x0000
+
+Interrupt polarity set [15:0]
+
+16
+
+0x0000
+
+Interrupt polarity clear [15:0]
+
+16
+
+0x0000
+
+Read interrupt status register
+Write 1: Clears the interrupt
+request
+
+16
+
+0x0000
+
+–
+
+16
+
+0x0000
+
+–
+
+–
+
+–
+
+Reserved
+
+2.11.11 Debug Access Port
+The Cortex-M3 processor contains a DAP that consists of a JTAG
+interface and a TPIU interface. Both of them interface to the FPGA Fabric.
+The JTAG-DAP is based on the IEEE1149.1 Joint Test Action Group
+Boundary-Scan Standard.
+JTAG-DP functions consist of the following three parts:
+
+DS861-1.8E
+
+
+
+JTAG-DP sate machine
+
+
+
+Instruction register (IR) and the related IR scan chain, which are used
+to control JTAG and the current register actions
+
+
+
+DR register and the related DR scan chain, which connect with the
+JTAG-DP register.
+
+40(63)
+
+2 Architecture
+
+2.12 Clocks
+
+2.11.12 Memory Mapping
+Figure 2-20 Memory Mapping
+0xFFFF_FFFF
+Reserved
+System
+Control
+Space
+0xE000_0000
+Reserved
+For External
+Devices
+0xA000_0000
+Reserved
+For External
+SRAM
+0x6000_0000
+Peripheral
+Reserved
+SRAM
+
+NVIC
+SysTick
+SCS
+
+0xE000_ED00
+0xE000_E100
+0xE000_E010
+0xE000_E000
+
+0x4001_1000
+GPIO
+0x4001_0000
+Watchdog
+0x4000_8000
+UART1
+0x4000_5000
+UART0
+0x4000_4000
+
+0x4000_0000
+
+Timer1
+
+0x2000_4000
+0x2000_0000
+
+Timer0
+
+Reserved
+Code flash
+
+SCB
+
+0x4000_1000
+0x4000_0000
+
+0x0002_0000
+0x0000_0000
+
+2.11.13 Application
+The Gowin software supports the call of Cortex-M3. For more
+information, please refer to IPUG932, Gowin_EMPU(GW1NS-4C)
+Hardware Design Reference Manual.
+
+2.12 Clocks
+The clock resources and wiring are critical for high-performance
+applications in FPGA. The GW1NSR series of FPGA products provide
+global clocks (GCLKs) which connect to all the registers directly. In
+addition, high-speed clocks (HCLKs), PLLs, etc. are provided.
+For more information on the GCLKs, HCLKs, PLLs, see UG286,
+Gowin Clock User Guide.
+
+2.12.1 Global Clocks
+The Global Clock(GCLK) resources are distributed across multiple
+quadrants within the GW1NSR series of FPGA products
+(Automotive).Each quadrant provides eight GCLKs. The clock sources of
+GCLKs include dedicated clock input pins and CRUs, and better clock
+performance can be achieved by using the dedicated clock input pins.
+
+2.12.2 PLLs
+The PLL (Phase-locked Loop) is a feedback control circuit. The
+frequency and phase of the internal oscillator signal are controlled by the
+external input reference clock.
+PLLs in the GW1NSR series of FPGA products can provide
+synthesizable clock frequencies. Frequency adjustment (multiplication and
+DS861-1.8E
+
+41(63)
+
+2 Architecture
+
+2.13 Long Wires
+
+division), phase adjustment, and duty cycle adjustment can be achieved
+by configuring the parameters.
+
+2.12.3 High-speed Clocks
+The high-speed clocks (HCLKs) are designed to facilitate highperformance I/O data transmission and are specifically tailored for source
+synchronous data transmission protocols. The GW1NSR-4C/4 devices
+have two HCLKs on each side, see Figure 2-21.
+Figure 2-21 GW1NSR-4/4C HCLK Distribution
+I/O Bank0
+
+I/O Bank1
+
+T
+
+I/O Bank2
+
+R
+
+B
+
+I/O Bank3
+IO Bank
+
+HCLK
+
+2.13 Long Wires
+As a supplement to the CRU, the GW1NSR series of FPGA products
+provide another kind of routing resource - the long wire, which can be
+used for clock, clock enable, set/reset, or other high fan-out signals.
+
+2.14 Global Set/Reset
+The GW1NSR series of FPGA products offer a dedicated global
+set/reset (GSR) network that connects directly to the device's internal logic
+and can be used as asynchronous/synchronous set or
+asynchronous/synchronous reset, with the registers in the CLUs and I/Os
+being able to be configured independently.
+
+DS861-1.8E
+
+42(63)
+
+2 Architecture
+
+2.15 Programming & Configuration
+
+2.15 Programming & Configuration
+The GW1NSR series of FPGA products support SRAM configuration
+and Flash programming. Flash programming includes on-chip Flash
+programming and off-chip Flash programming.
+In addition to JTAG, the GW1NSR series of FPGA products also
+support Gowin’s own GowinCONFIG configuration modes: AUTO BOOT,
+SSPI, MSPI, DUAL BOOT, SERIAL, and CPU. All the GW1NSR FPGAs
+support JTAG mode and AUTO BOOT mode. For more information, please
+refer to UG290, Gowin FPGA Products Programming and Configuration
+User Guide.
+
+2.15.1 SRAM Configuration
+If SRAM configuration is used, the configuration data needs to be redownloaded after each power-up.
+
+2.15.2 Flash Programming
+The Flash programming data is stored in the on-chip Flash. Each time
+the device is powered up, the configuration data is transferred from the
+Flash to the SRAM. Configuration can be completed within a few
+milliseconds after power-up, which is why this kind of configuration is also
+known as “instant on”.
+In addition, the GW1NSR series of FPGA products support off-chip
+Flash programming and DUAL BOOT. For more information, please refer
+to UG290, Gowin FPGA Products Programming and Configuration User
+Guide.
+The GW1NSR series of FPGA products support the feature of
+background upgrade. That is to say, you can program the on-chip Flash or
+off-chip Flash via the JTAG[1] interface without affecting the current
+working state. During programming, the device works according to the
+previous configuration. After the programming is done, you can trigger
+RECONFIG_N[2] with a low level to complete the upgrade. This feature is
+suitable for the applications requiring long online time and irregular
+upgrades.
+Note!
+
+
+[1]
+
+
+
+[2]
+
+For the GW1NSR-4C device, the JTAG background upgrade feature is not
+available if its embedded Cortex-M3 is used.
+As a configuration pin, RECONFIG_N is an input pin with internal weak pull-up,
+but as a GPIO, RECONFIG_N can only be used for output. For more information,
+please refer to UG290, Gowin FPGA Products Programming and Configuration User
+Guide.
+
+2.16 On-chip Oscillator
+The GW1NSR series of FPGA products have an embedded
+programmable on-chip clock oscillator which provides a clock source for
+the MSPI configuration mode with a tolerance of ±5%.
+The on-chip oscillator of the GW1NSR-4C/4 device supports userDS861-1.8E
+
+43(63)
+
+2 Architecture
+
+2.16 On-chip Oscillator
+
+configurable power saving mode.
+The on-chip oscillator also provides a clock resource for user designs.
+Up to 64 clock frequencies can be obtained by setting the parameters.
+The following formula is used to get the output clock frequency of the
+on-chip oscillator of GW1NSR-4C/4:
+fout=fosc/Param
+Note!
+For C7/I6 speed grade devices, fosc is 260MHz; for other speed grade devices, fosc is
+250MHz. “Param” should be even numbers from 2 to 128.
+
+The table below lists some frequencies provided by the on-chip
+oscillator for fosc = 250 MHz.
+Table 2-15 Output Frequency Options of the On-chip Oscillator of GW1NSR-4/4C
+Mode
+
+Frequency
+
+Mode
+
+Frequency
+
+Mode
+
+Frequency
+
+0
+
+2.5MHz[1]
+
+8
+
+7.8MHz
+
+16
+
+15.6MHz
+
+1
+
+5.4MHz
+
+9
+
+8.3MHz
+
+17
+
+17.9MHz
+
+2
+
+5.7MHz
+
+10
+
+8.9MHz
+
+18
+
+21MHz
+
+3
+
+6.0MHz
+
+11
+
+9.6MHz
+
+19
+
+25MHz
+
+4
+
+6.3MHz
+
+12
+
+10.4MHz
+
+20
+
+31.3MHz
+
+5
+
+6.6MHz
+
+13
+
+11.4MHz
+
+21
+
+41.7MHz
+
+6
+
+6.9MHz
+
+14
+
+12.5MHz
+
+22
+
+62.5MHz
+
+7
+
+7.4MHz
+
+15
+
+13.9MHz
+
+23
+
+125MHz[2]
+
+Note!
+
+DS861-1.8E
+
+
+
+[1]
+
+Default frequency.
+
+
+
+[2]
+
+This is not available for the MSPI configuration mode.
+
+44(63)
+
+3 DC and Switching Characteristics
+
+3.1 Operating Conditions
+
+3
+
+DC and Switching Characteristics
+
+Note!
+Please ensure that you use Gowin’s devices within the recommended operating
+conditions and ranges. Data beyond the working conditions and ranges are for reference
+only. Gowin does not guarantee that all devices will operate normally beyond the
+operating conditions and ranges.
+
+3.1 Operating Conditions
+3.1.1 Absolute Max. Ratings
+Table 3-1 Absolute Max. Ratings
+Name
+
+Description
+
+Min.
+
+Max.
+
+VCC
+
+Core voltage
+
+-0.5V
+
+1.32V
+
+VCCIOx
+
+I/O Bank voltage
+
+-0.5V
+
+3.75V
+
+VCCX
+
+Auxiliary voltage(LV version)
+
+-0.5V
+
+3.75V
+
+-
+
+I/O voltage applied[1]
+
+-0.5V
+
+3.75V
+
+Storage Temperature
+
+Storage temperature
+
+-65℃
+
++150℃
+
+Junction Temperature
+
+Junction temperature
+
+-40℃
+
++125℃
+
+Note!
+[1]
+
+Overshoot and undershoot of -2V to (VIHMAX + 2)V are allowed for a duration of <20 ns.
+
+3.1.2 Recommended Operating Conditions
+Table 3-2 Recommended Operating Conditions
+Name
+
+Description
+
+Min.
+
+Max.
+
+VCC
+
+Core voltage
+
+1.14V
+
+1.26V
+
+VCCX
+
+Auxiliary voltage(LV version)
+
+1.71V
+
+3.6V
+
+VCCIOx
+
+I/O Bank voltage (LV version)
+
+TJCOM
+
+Junction temperature for commercial operations
+
+1.14V
+0℃
+
+3.6V
++85℃
+
+TJIND
+
+Junction temperature for industrial operations
+
+-40℃
+
++100℃
+
+Note!
+
+
+DS861-1.8E
+
+For more information on the power supplies, please refer to UG864, GW1NSR-4
+Pinout and UG865, GW1NSR-4C Pinout .
+45(63)
+
+3 DC and Switching Characteristics
+
+
+
+3.1 Operating Conditions
+
+The allowable ripples on VCC, VCCIO, and VCCX are 3%, 5%, and 5% respectively. 1).
+For devices of which the PLL is powered directly with VCC, the ripple on VCC can
+affect the jitter characteristics of the PLL output clock; 2). The ripple on VCCIO can
+eventually be passed on to the output waveform of the IO Buffer.
+
+3.1.3 Power Supply Ramp Rates
+Table 3-3 Power Supply Ramp Rates
+Name
+
+Description
+
+Min.
+
+Typ.
+
+Max.
+
+VCC Ramp
+
+Power supply ramp rates for VCC
+
+0.6mV/μs
+
+-
+
+6mV/μs
+
+VCCX Ramp
+
+Power supply ramp rates for VCCX
+
+0.6mV/μs
+
+-
+
+10mV/μs
+
+VCCIO Ramp
+
+Power supply ramp rates for VCCIO
+
+0.1mV/μs
+
+-
+
+10mV/μs
+
+Note!
+
+
+A monotonic ramp is required for all power supplies.
+
+
+
+All power supplies need to be in the operating range as defined in Table 4-2 before
+configuration. Power supplies that are not in the operating range need to be adjusted
+to a faster ramp rate, or you have to delay configuration.
+
+3.1.4 Hot Socketing Specifications
+Table 3-4 Hot Socketing Specifications
+Name
+
+Description
+
+Condition
+
+I/O Type
+
+Max.
+
+IHS
+
+Input or I/O leakage current
+
+0<VIN<VIH(MAX)
+
+150uA
+
+IHS
+
+Input or I/O leakage current
+
+0<VIN<VIH(MAX)
+
+I/O
+TDI,TDO,
+TMS,TCK
+
+120uA
+
+3.1.5 POR Specifications
+Table 3-5 POR Parameters
+Name
+
+Description
+
+Min.
+
+Max.
+
+POR Voltage
+
+Power on reset voltage of Vcc
+
+TBD
+
+TBD
+
+DS861-1.8E
+
+46(63)
+
+3 DC and Switching Characteristics
+
+3.2 ESD performance
+
+3.2 ESD performance
+Table 3-6 GW1NSR ESD - HBM
+Device
+
+QN48
+
+MG64
+
+GW1NSR-4C
+
+HBM>1,000V
+
+HBM>1,000V
+
+GW1NSR-4
+
+-
+
+HBM>1,000V
+
+Table 3-7 GW1NSR ESD - CDM
+Device
+
+QN48
+
+MG64
+
+GW1NSR-4C
+
+CDM>500V
+
+CDM>500V
+
+GW1NSR-4
+
+-
+
+CDM>500V
+
+3.3 DC Electrical Characteristics
+3.3.1 DC Electrical Characteristics over Recommended Operating
+Conditions
+Table 3-8 DC Electrical Characteristics over Recommended Operating Conditions
+Name
+
+Description
+
+Condition
+
+Min.
+
+Typ.
+
+Max.
+
+IIL,IIH
+
+Input
+or
+I/O
+leakage current
+
+VCCIO<VIN<VIH(MAX)
+
+-
+
+-
+
+210µA
+
+0V<VIN<VCCIO
+
+-
+
+-
+
+10µA
+
+0<VIN<0.7VCCIO
+
+-30µA
+
+-
+
+-150µA
+
+VIL(MAX)<VIN<VCCIO
+
+30µA
+
+-
+
+150µA
+
+VIN=VIL(MAX)
+
+30µA
+
+-
+
+-
+
+VIN=0.7VCCIO
+
+-30µA
+
+-
+
+-
+
+0≤VIN≤VCCIO
+
+-
+
+-
+
+150µA
+
+0≤VIN≤VCCIO
+
+-
+
+-
+
+-150µA
+
+VIL(MAX)
+
+-
+
+VIH(MIN)
+
+5pF
+
+8pF
+
+-
+
+200mV
+
+-
+
+VCCIO=2.5V, Hysteresis= L2H
+
+-
+
+125mV
+
+-
+
+VCCIO=1.8V, Hysteresis= L2H
+
+-
+
+60mV
+
+-
+
+VCCIO=1.5V, Hysteresis= L2H
+
+-
+
+40mV
+
+-
+
+VCCIO=1.2V, Hysteresis= L2H
+
+-
+
+20mV
+
+-
+
+VCCIO=3.3V, Hysteresis= H2L[1],[2]
+
+-
+
+200mV
+
+-
+
+VCCIO=2.5V, Hysteresis= H2L
+
+-
+
+125mV
+
+-
+
+VCCIO=1.8V, Hysteresis= H2L
+
+-
+
+60mV
+
+-
+
+VCCIO=1.5V, Hysteresis= H2L
+
+-
+
+40mV
+
+-
+
+VCCIO=1.2V, Hysteresis= H2L
+
+-
+
+20mV
+
+-
+
+IPU
+IPD
+IBHLS
+IBHHS
+IBHLO
+IBHHO
+VBHT
+C1
+
+I/O Active Pull-up
+Current
+I/O Active Pulldown Current
+Bus Hold Low
+Sustaining Current
+Bus Hold High
+Sustaining Current
+Bus Hold Low
+Overdrive Current
+Bus Hold High
+Overdrive Current
+Bus
+Hold
+Trip
+Points
+I/O Capacitance
+
+VCCIO
+
+VHYST
+
+DS861-1.8E
+
+Hysteresis
+for
+Schmitt
+Trigger
+inputs
+
+=3.3V, Hysteresis=L2H[1],[2]
+
+47(63)
+
+3 DC and Switching Characteristics
+
+Name
+
+Description
+
+3.3 DC Electrical Characteristics
+
+Condition
+VCCIO=3.3V,
+Hysteresis=
+HIGH[1],[2]
+VCCIO=2.5V, Hysteresis= HIGH
+
+Min.
+
+Typ.
+
+Max.
+
+-
+
+400mV
+
+-
+
+-
+
+250mV
+
+-
+
+VCCIO=1.8V, Hysteresis= HIGH
+
+-
+
+120mV
+
+-
+
+VCCIO=1.5V, Hysteresis= HIGH
+
+-
+
+80mV
+
+-
+
+VCCIO=1.2V, Hysteresis= HIGH
+
+-
+
+40mV
+
+-
+
+Note!
+
+
+[1]
+
+
+
+[2]
+
+Hysteresis=“NONE”, “L2H”, “H2L”, “HIGH” indicates the Hysteresis options that
+can be set when setting I/O Constraints in the FloorPlanner tool of Gowin EDA, for
+more details, see SUG935, Gowin Design Physical Constraints User Guide.
+
+VIH (L2H on)
+VIL (None)
+
+VHYST
+
+VIH (None)
+
+VHYST
+
+Enabling the L2H (low to high) option means raising VIH by VHYST; enabling the
+H2L (high to low) option means lowering VIL by VHYST; enabling the HIGH option
+means enabling both L2H and H2L options, i.e. VHYST(HIGH) = VHYST(L2H) +
+VHYST(H2L). The diagram is shown below.
+
+VIL (H2L on)
+
+3.3.2 Static Current
+Table 3-9 Static Current[1]
+Name
+
+Description
+
+Device
+type
+
+Device
+
+C7/I6
+
+C6/I5
+
+C5/I4
+
+ICC
+
+VCC current (VCC=1.2V)
+
+LV version
+
+GW1NSR4/4C
+
+12mA
+
+2.8mA
+
+2.8mA
+
+VCCX current (VCCX=2.5V)
+
+LV version
+
+GW1NSR4/4C
+
+-
+
+1.2mA
+
+1.2mA
+
+VCCX current (VCCX=3.3V)
+
+LV version
+
+GW1NSR4/4C
+
+3mA
+
+-
+
+-
+
+VCCIO current (VCCIO=2.5V)
+
+LV version
+
+GW1NSR4/4C
+
+1mA
+
+0.7mA
+
+0.7mA
+
+ICCX
+
+ICCIO[2]
+
+Note!
+
+DS861-1.8E
+
+
+
+[1]
+
+
+
+[2]
+
+The values in the table are typical values at 25℃.
+
+There are two PSRAMs integrated in GW1NSR-4/4C MG64P, and the VCCIO static
+current will increase by 300uA x 2=600uA when it is used. There is one HyperRAM
+integrated in GW1NSR-4C QN48P, and the VCCIO static current will increase by
+220uA when it is used. There is one NOR Flash integrated in GW1NSR-4C QN48G,
+and the VCCIO static current will increase by 40uA when it is used.
+
+48(63)
+
+3 DC and Switching Characteristics
+
+3.3 DC Electrical Characteristics
+
+3.3.3 Recommended I/O Operating Conditions
+Table 3-10 Recommended I/O Operating Conditions
+Name
+
+VCCIO (V) for Output
+
+VREF (V) for Input
+
+Min.
+
+Typ.
+
+Max.
+
+Min.
+
+Typ.
+
+Max.
+
+LVTTL33
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+LVCMOS33
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+LVCMOS25
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+LVCMOS18
+
+1.71
+
+1.8
+
+1.89
+
+-
+
+-
+
+-
+
+LVCMOS15
+
+1.425
+
+1.5
+
+1.575
+
+-
+
+-
+
+-
+
+LVCMOS12
+
+1.14
+
+1.2
+
+1.26
+
+-
+
+-
+
+-
+
+SSTL15
+
+1.425
+
+1.5
+
+1.575
+
+0.68
+
+0.75
+
+0.9
+
+SSTL18_I
+
+1.71
+
+1.8
+
+1.89
+
+0.833
+
+0.9
+
+0.969
+
+SSTL18_II
+
+1.71
+
+1.8
+
+1.89
+
+0.833
+
+0.9
+
+0.969
+
+SSTL25_I
+
+2.375
+
+2.5
+
+2.645
+
+1.15
+
+1.25
+
+1.35
+
+SSTL25_II
+
+2.375
+
+2.5
+
+2.645
+
+1.15
+
+1.25
+
+1.35
+
+SSTL33_I
+
+3.135
+
+3.3
+
+3.6
+
+1.3
+
+1.5
+
+1.7
+
+SSTL33_II
+
+3.135
+
+3.3
+
+3.6
+
+1.3
+
+1.5
+
+1.7
+
+HSTL18_I
+
+1.71
+
+1.8
+
+1.89
+
+0.816
+
+0.9
+
+1.08
+
+HSTL18_II
+
+1.71
+
+1.8
+
+1.89
+
+0.816
+
+0.9
+
+1.08
+
+HSTL15
+
+1.425
+
+1.5
+
+1.575
+
+0.68
+
+0.75
+
+0.9
+
+PCI33
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+LVPECL33E
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+MLVDS25E
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+BLVDS25E
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+RSDS25E
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+LVDS25E
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+SSTL15D
+
+1.425
+
+1.5
+
+1.575
+
+-
+
+-
+
+-
+
+SSTL18D_I
+
+1.71
+
+1.8
+
+1.89
+
+-
+
+-
+
+-
+
+SSTL18D_II
+
+1.71
+
+1.8
+
+1.89
+
+-
+
+-
+
+-
+
+SSTL25D_I
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+SSTL25D_II
+
+2.375
+
+2.5
+
+2.625
+
+-
+
+-
+
+-
+
+SSTL33D_I
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+SSTL33D_II
+
+3.135
+
+3.3
+
+3.6
+
+-
+
+-
+
+-
+
+HSTL15D
+
+1.425
+
+1.575
+
+1.89
+
+-
+
+-
+
+-
+
+HSTL18D_I
+
+1.71
+
+1.8
+
+1.89
+
+-
+
+-
+
+-
+
+HSTL18D_II
+
+1.71
+
+1.8
+
+1.89
+
+-
+
+-
+
+-
+
+DS861-1.8E
+
+49(63)
+
+3 DC and Switching Characteristics
+
+3.3 DC Electrical Characteristics
+
+3.3.4 Single-ended I/O DC Characteristics
+Table 3-11 Single-ended I/O DC Characteristics
+Name
+
+LVCMOS33
+LVTTL33
+
+VIL
+Min
+
+-0.3V
+
+VIH
+Max
+
+0.8V
+
+Min
+
+2.0V
+
+Max
+
+3.6V
+
+VOL
+(Max)
+
+0.4V
+
+0.2V
+
+LVCMOS25
+
+-0.3V
+
+0.7V
+
+1.7V
+
+3.6V
+
+0.4V
+
+0.2V
+0.4V
+LVCMOS18
+
+-0.3V
+
+0.35*VCCIO
+
+0.65*VCCIO
+
+LVCMOS12
+
+-0.3V
+
+-0.3V
+
+0.35*VCCIO
+
+0.35*VCCIO
+
+0.65*VCCIO
+
+0.65*VCCIO
+
+VCCIO-0.4V
+
+VCCIO-0.2V
+
+VCCIO-0.4V
+
+VCCIO-0.2V
+VCCIO-0.4V
+
+3.6V
+0.2V
+
+LVCMOS15
+
+VOH
+(Min)
+
+3.6V
+
+3.6V
+
+VCCIO-0.2V
+
+IOL[1]
+(mA)
+
+IOH[1]
+(mA)
+
+4
+
+-4
+
+8
+
+-8
+
+12
+
+-12
+
+16
+
+-16
+
+24
+
+-24
+
+0.1
+
+-0.1
+
+4
+
+-4
+
+8
+
+-8
+
+12
+
+-12
+
+16
+
+-16
+
+0.1
+
+-0.1
+
+4
+
+-4
+
+8
+
+-8
+
+12
+
+-12
+
+0.1
+
+-0.1
+
+4
+
+-4
+
+8
+
+-8
+
+0.1
+
+-0.1
+
+4
+
+-4
+
+8
+
+-8
+
+0.4V
+
+VCCIO-0.4V
+
+0.2V
+
+VCCIO-0.2V
+
+0.4V
+
+VCCIO-0.4V
+
+0.2V
+
+VCCIO-0.2V
+
+0.1
+
+-0.1
+
+PCI33
+
+-0.3V
+
+0.3*VCCIO
+
+0.5*VCCIO
+
+3.6V
+
+0.1*VCCIO 0.9*VCCIO
+
+1.5
+
+-0.5
+
+SSTL33_I
+
+-0.3V
+
+VREF-0.2V
+
+VREF+0.2V
+
+3.6V
+
+0.7
+
+VCCIO-1.1V
+
+8
+
+-8
+
+SSTL25_I
+
+-0.3V
+
+VREF-0.18V
+
+VREF+0.18V
+
+3.6V
+
+0.54V
+
+VCCIO-0.62V 8
+
+-8
+
+SSTL25_II
+
+-0.3V
+
+VREF-0.18V
+
+VREF+0.18V
+
+3.6V
+
+NA
+
+NA
+
+NA
+
+NA
+
+SSTL18_II
+
+-0.3V
+
+VREF-0.125V
+
+VREF+0.125V
+
+3.6V
+
+NA
+
+NA
+
+NA
+
+NA
+
+SSTL18_I
+
+-0.3V
+
+VREF-0.125V
+
+VREF+0.125V
+
+3.6V
+
+0.40V
+
+VCCIO-0.40V 8
+
+-8
+
+SSTL15
+
+-0.3V
+
+VREF-0.1V
+
+VREF+ 0.1V
+
+3.6V
+
+0.40V
+
+VCCIO-0.40V 8
+
+-8
+
+HSTL18_I
+
+-0.3V
+
+VREF-0.1V
+
+VREF+ 0.1V
+
+3.6V
+
+0.40V
+
+VCCIO-0.40V 8
+
+-8
+
+HSTL18_II
+
+-0.3V
+
+VREF-0.1V
+
+VREF+ 0.1V
+
+3.6V
+
+NA
+
+NA
+
+NA
+
+HSTL15_I
+
+-0.3V
+
+VREF-0.1V
+
+VREF+ 0.1V
+
+3.6V
+
+0.40V
+
+VCCIO-0.40V 8
+
+-8
+
+HSTL15_II
+
+-0.3V
+
+VREF-0.1V
+
+VREF+ 0.1V
+
+3.6V
+
+NA
+
+NA
+
+NA
+
+NA
+NA
+
+Note!
+[1]
+
+The total DC current limit(sourced and sunk current) of all IOs in the same bank: the
+total DC current of all IOs in the same bank shall not be greater than n*8mA, where n
+represents the number of IOs bonded out from a bank.
+DS861-1.8E
+
+50(63)
+
+3 DC and Switching Characteristics
+
+3.4 Switching Characteristics
+
+3.3.5 Differential I/O DC Characteristics
+Table 3-12 Differential I/O DC Characteristics (LVDS)
+Name
+
+Description
+
+VINA,VINB
+
+Input Voltage
+
+VCM
+
+Input Common Mode Voltage
+
+VTHD
+
+Differential Input Threshold
+
+IIN
+
+Input Current
+
+VOL
+
+Output High Voltage for VOP or
+VOM
+Output Low Voltage for VOP or VOM
+
+VOD
+
+Output Voltage Differential
+
+ΔVOD
+
+Change in VOD Between High and
+Low
+
+VOS
+
+Output Voltage Offset
+
+ΔVOS
+
+Change in VOS Between High and
+Low
+
+IS
+
+Short-circuit current
+
+VOH
+
+Test conditions
+
+Min.
+
+Typ.
+
+Max.
+
+Unit
+
+0
+
+-
+
+2.15
+
+V
+
+0.05
+
+-
+
+2.1
+
+V
+
+±100
+
+-
+
+±600
+
+mV
+
+-
+
+-
+
+±20
+
+µA
+
+RT = 100Ω
+
+-
+
+-
+
+1.60
+
+V
+
+RT = 100Ω
+(VOP
+RT=100Ω
+
+0.9
+
+-
+
+-
+
+V
+
+250
+
+350
+
+450
+
+mV
+
+-
+
+-
+
+50
+
+mV
+
+1.125
+
+1.20
+
+1.375
+
+V
+
+-
+
+-
+
+50
+
+mV
+
+-
+
+-
+
+15
+
+mA
+
+Half the Sum of
+the Two Inputs
+Difference
+Between the Two
+Inputs
+Power
+On
+or
+Power Off
+
+VOM),
+
+(VOP + VOM)/2,
+RT=100Ω
+VOD = 0V outputs
+short-circuited
+
+3.4 Switching Characteristics
+3.4.1 CLU Switching Characteristics
+Table 3-13 CLU Timing Parameters
+Name
+
+Description
+
+tLUT4_CLU
+
+Speed Grade
+
+Unit
+
+Min
+
+Max
+
+LUT4 delay
+
+-
+
+0.674
+
+ns
+
+tSR_CLU
+
+Set/Reset to Register output
+
+-
+
+1.86
+
+ns
+
+tCO_CLU
+
+Clock to Register output
+
+-
+
+0.76
+
+ns
+
+DS861-1.8E
+
+51(63)
+
+3 DC and Switching Characteristics
+
+3.4 Switching Characteristics
+
+3.4.2 Clock and I/O Switching Characteristics
+Table 3-14 External Switching Characteristics
+C5/I4
+
+Name
+
+C6/I5
+
+Unit
+
+Min
+
+Max
+
+Min
+
+Max
+
+HCLK Tree delay
+
+0.8
+
+1.4
+
+0.5
+
+1.2
+
+ns
+
+PCLK Tree delay(GCLK0~5)
+
+1.4
+
+2.6
+
+1.0
+
+2.2
+
+ns
+
+PCLK Tree delay(GCLK6~7)
+
+1.8
+
+3.2
+
+1.4
+
+2.9
+
+ns
+
+Pin-LUT-Pin Delay
+
+3.4
+
+5
+
+3
+
+4.5
+
+ns
+
+3.4.3 Gearbox Switching Characteristics
+Table 3-15 Gearbox Timing Parameters
+Name
+
+Description
+
+Typ.
+
+Unit
+
+FMAXIDDR
+FMAXIDES4
+FMAXIDES7
+FMAXIDESx
+FMAXODDR
+FMAXOSER4
+FMAXOSER7
+FMAXOSERx
+
+1:2 Gearbox maximum serial input rate
+1:4 Gearbox maximum serial input rate
+1:7 Gearbox maximum serial input rate
+1:8/1:10/1:16 Gearbox maximum serial input rate
+2:1 Gearbox maximum serial output rate
+4:1 Gearbox maximum serial output rate
+7:1 Gearbox maximum serial output rate
+8:1/10:1/16:1 Gearbox maximum serial output rate
+
+400
+800
+1000
+1100
+400
+800
+1000
+1100
+
+Mbps
+Mbps
+Mbps
+Mbps
+Mbps
+Mbps
+Mbps
+Mbps
+
+Table 3-16 Single-ended IO Fmax
+Name
+
+Fmax
+Min.(MHz)
+Drive Strength = 4mA
+
+Drive Strength > 4mA
+
+LVTTL33
+
+150
+
+LVCMOS33
+
+150
+
+LVCMOS25
+
+150
+
+LVCMOS18
+
+150
+
+LVCMOS15
+
+150
+
+LVCMOS12
+
+150
+
+300
+300
+300
+300
+200
+150
+
+Note!
+Test load = 30pF.
+
+DS861-1.8E
+
+52(63)
+
+3 DC and Switching Characteristics
+
+3.4 Switching Characteristics
+
+3.4.4 BSRAM Switching Characteristics
+Table 3-17 BSRAM Timing Parameters
+Name
+
+Description
+
+tCOAD_BSRAM
+tCOOR_BSRAM
+
+Clock to output time of read address/data
+Clock to output time of output register
+
+Speed Grade
+Min
+Max
+5.10
+0.56
+
+Unit
+ns
+ns
+
+3.4.5 DSP Switching Characteristics
+Table 3-18 DSP Timing Parameters
+Name
+
+Description
+
+tCOIR_DSP
+tCOPR_DSP
+tCOOR_DSP
+
+Clock to output time of input register
+Clock to output time of pipeline register
+Clock to output time of output register
+
+Speed Grade
+Min
+Max
+4.80
+2.40
+0.84
+
+Unit
+ns
+ns
+ns
+
+3.4.6 On-chip Oscillator Switching Characteristics
+Table 3-19 On-chip Oscillator Parameters
+Name
+
+fMAX
+
+Description
+On-chip Oscillator
+Output Frequency
+(0 ~ +85℃)
+On-chip Oscillator
+Output Frequency
+(-40 ~ +100℃)
+
+Min.
+
+Typ.
+
+Max.
+
+GW1NSR-4/4C
+
+118.75MHz
+
+125MHz
+
+131.25MHz
+
+GW1NSR-4/4C
+
+112.5MHz
+
+125MHz
+
+137.5MHz
+
+tDT
+
+Output Clock Duty Cycle
+
+43%
+
+50%
+
+57%
+
+tOPJIT
+
+Output Clock Period Jitter
+
+0.01UIPP
+
+0.012UIPP
+
+0.02UIPP
+
+DS861-1.8E
+
+53(63)
+
+3 DC and Switching Characteristics
+
+3.5 Cortex-M3 AC/DC Characteristics
+
+3.4.7 PLL Switching Characteristics
+Table 3-20 PLL Parameters
+Device
+
+Speed Grade
+
+Name
+
+Min.
+
+Max.
+
+CLKIN
+
+3MHz
+
+400MHz
+
+C7/I6
+
+PFD
+
+3MHz
+
+400MHz
+
+C6/I5
+
+VCO
+
+400MHz
+
+1200MHz
+
+CLKOUT
+
+3.125MHz
+
+600MHz
+
+CLKIN
+
+3MHz
+
+320MHz
+
+PFD
+
+3MHz
+
+320MHz
+
+VCO
+
+320MHz
+
+960MHz
+
+CLKOUT
+
+2.5MHz
+
+480MHz
+
+GW1NSR-4/
+GW1NSR-4C
+C5/I4
+
+3.5 Cortex-M3 AC/DC Characteristics
+3.5.1 DC Electrical Characteristics
+Table 3-21 Current Characteristics
+Symbol
+
+Description
+
+IVCC
+
+Specification
+
+Unit
+
+Min.
+
+Max.
+
+Max. current of VCC
+
+-
+
+100
+
+mA
+
+IVSS
+
+Max. current of VSS
+
+-
+
+-100
+
+mA
+
+IINJ
+
+Leakage current
+
+-
+
++/-5
+
+mA
+
+3.5.2 AC Electrical Characteristics
+Table 3-22 Clock Parameters
+Symbol
+
+Description
+
+Device
+
+fHCLK
+
+AHB clock
+frequency
+
+fPCLK
+
+APB clock
+frequency
+
+DS861-1.8E
+
+Specification
+
+Unit
+
+Min.
+
+Max.
+
+GW1NSR-4C
+
+0
+
+80
+
+MHz
+
+GW1NSR-4C
+
+0
+
+80
+
+MHz
+
+54(63)
+
+3 DC and Switching Characteristics
+
+3.6 User Flash Characteristics(GW1NSR-4)
+
+3.6 User Flash Characteristics(GW1NSR-4)
+3.6.1 DC Electrical Characteristics
+Table 3-23 GW1NSR-4 User Flash DC Characteristics[1], [4]
+Parame
+ter
+
+Name
+Read mode(w/I
+25ns)
+Write mode
+
+ICC1[2]
+
+Erase mode
+Page
+erase
+mode
+Static
+current
+50ns)
+
+read
+(25-
+
+Standby mode
+
+Max.
+
+Unit
+
+Wake-up
+time
+
+0.5
+
+mA
+
+NA
+
+0.1
+
+12
+
+mA
+
+NA
+
+Minimum clock period, 100%
+duty cycle , VIN = “1/0”
+–
+
+0.1
+
+12
+
+mA
+
+NA
+
+–
+
+0.1
+
+12
+
+mA
+
+NA
+
+–
+
+VCC[3]
+
+VCCX
+
+2.19
+
+ICC2
+
+980
+
+25
+
+μA
+
+NA
+
+ISB
+
+5.2
+
+20
+
+μA
+
+0
+
+Condition
+
+XE=YE=SE=“1”,
+between
+T=Tacc and T=50ns, the I/O
+current is 0mA. After T=50ns,
+the internal timer turns off read
+mode, and the I/O current turns
+out to be the standby current.
+VSS, VCCX, and VCC
+
+Note!
+
+
+[1]
+
+
+
+[2]
+
+
+
+DS861-1.8E
+
+These values are average DC currents and the peak currents will be higher than
+these average currents.
+ICC1 calculation in different cycle time of Tnew.
+
+-
+
+Tnew< Tacc: not allowed.
+
+-
+
+Tnew = Tacc : see the table above.
+
+-
+
+Tacc<Tnew - 50ns：ICC1 (new) = (ICC1 - ICC2)(Tacc/Tnew) + ICC2
+
+-
+
+Tnew>50ns：ICC1 (new) = (ICC1 - ICC2)(Tacc/Tnew) + 50ns*ICC2/Tnew + ISB
+
+-
+
+t > 50ns：ICC2 = ISB
+
+[3]
+
+VCC must be greater than 1.08V from time zero of the wake-up time.
+
+55(63)
+
+3 DC and Switching Characteristics
+
+3.6 User Flash Characteristics(GW1NSR-4)
+
+3.6.2 AC Electrical Characteristics
+Table 3-24 GW1NSR-4 User Flash Parameters[1], [4], [5]
+User Mode
+
+Parameter
+
+Symbol
+
+Min.
+
+Max.
+
+Unit
+
+-
+
+25
+
+ns
+
+-
+
+22
+
+ns
+
+-
+
+21
+
+ns
+
+LT
+
+-
+
+21
+
+ns
+
+WC
+
+-
+
+25
+
+ns
+
+WC1
+TC
+Access time
+
+BC
+
+Tacc
+
+[2]
+
+Program/Erase to data storage setup time
+
+Tnvs
+
+5
+
+-
+
+μs
+
+Data storage hold time
+
+Tnvh
+
+5
+
+-
+
+μs
+
+Data storage hold time(mass erase)
+
+Tnvh1
+
+100
+
+-
+
+μs
+
+Data storage to program setup time
+
+Tpgs
+
+10
+
+-
+
+μs
+
+Program hold time
+
+Tpgh
+
+20
+
+-
+
+ns
+
+Program time
+
+Tprog
+
+8
+
+16
+
+μs
+
+Write prepare time
+
+Twpr
+
+>0
+
+-
+
+ns
+
+Write hold time
+
+Twhd
+
+>0
+
+-
+
+ns
+
+Control to program/erase setup time
+
+Tcps
+
+-10
+
+-
+
+ns
+
+SE to read control setup time
+
+Tas
+
+0.1
+
+-
+
+ns
+
+Positive pulse width of SE
+
+Tpws
+
+5
+
+-
+
+ns
+
+Address/data setup time
+
+Tads
+
+20
+
+-
+
+ns
+
+Address/data hold time
+
+Tadh
+
+20
+
+-
+
+ns
+
+Data hold time
+
+Tdh
+
+0.5
+
+-
+
+ns
+
+WC1
+
+Tah
+
+25
+
+-
+
+ns
+
+TC
+
+-
+
+22
+
+-
+
+ns
+
+BC
+
+-
+
+21
+
+-
+
+ns
+
+LT
+
+-
+
+21
+
+-
+
+ns
+
+WC
+
+-
+
+25
+
+-
+
+ns
+
+Negative pulse width of SE
+
+Tnws
+
+2
+
+-
+
+ns
+
+Recovery time
+
+Trcv
+
+10
+
+-
+
+μs
+
+Data storage time
+
+Thv[3]
+
+-
+
+6
+
+ms
+
+Erase time
+
+Terase
+
+100
+
+120
+
+ms
+
+Mass erase time
+
+Tme
+
+100
+
+120
+
+ms
+
+Wake-up time of power-down to standby
+
+Twk_pd
+
+7
+
+-
+
+μs
+
+Standby hold time
+
+Tsbh
+
+100
+
+-
+
+ns
+
+VCC setup time
+
+Tps
+
+0
+
+-
+
+ns
+
+VCCX hold time
+
+Tph
+
+0
+
+-
+
+ns
+
+Address hold time in
+read mode
+
+Note!
+
+DS861-1.8E
+
+
+
+[1]
+
+
+
+[2]
+
+The values are simulation data and are subject to change.
+
+After XADR, YADR, XE, and YE are valid, Tacc starts at the rising edge of SE.
+DOUT will be kept before the next valid read operation starts.
+56(63)
+
+3 DC and Switching Characteristics
+
+
+
+[3]
+
+
+
+[4]
+
+
+
+[5]
+
+3.6 User Flash Characteristics(GW1NSR-4)
+
+Thv is the cumulative time from the start of the write operation to the next data
+erase operation. The same address cannot be written twice before the next erase;
+the same memory cell cannot be written twice before the next erase. This limitation
+is for security reasons.
+All waveforms have a 1ns rising time and a 1ns falling time.
+
+Control signals(X, YADR, XE, and YE) need to be held for at least Tacc, which
+starts at the rising edge of SE.
+
+3.6.3 Timing Diagrams
+Figure 3-1 Read Timing
+
+Figure 3-2 Program Timing
+
+DS861-1.8E
+
+57(63)
+
+3 DC and Switching Characteristics
+
+3.7 Configuration Interface Timing Specification
+
+Figure 3-3 Erase Timing
+
+3.7 Configuration Interface Timing Specification
+The GW1NSR series of FPGA products support 6 GowinCONFIG
+modes: AUTO BOOT, SSPI, MSPI, DUAL BOOT, SERIAL, and CPU. For
+more information, please refer to UG290, Gowin FPGA Products
+Programming and Configuration User Guide.
+
+DS861-1.8E
+
+58(63)
+
+4 Ordering Information
+
+4.1 Part Naming
+
+4
+
+Ordering Information
+
+4.1 Part Naming
+Note!
+
+
+For more information about the packages, please refer to 1.2 Product Resources
+and 1.3 Package Information.
+
+
+
+The LittleBee family devices and Arora family devices of the same speed grade have
+different speeds.
+
+
+
+Both “C” and “I” are used in Gowin’s part name marking for one device. GOWIN
+devices are screened using industrial standards, so the same device can be used for
+both industrial (I) and commercial (C) applications. The maximum temperature of the
+industrial grade is 100℃, and the maximum temperature of the commercial grade is
+85℃. Therefore, if the chip meets speed grade 6 in commercial grade applications,
+its speed grade will be 5 in industrial grade applications.
+
+Figure 4-1 Part Naming Examples for GW1NSR-4 Devices– ES
+
+GW1NSR - XX XX XXXXXX ES
+Product Series
+GW1NSR
+
+Optional Suffix
+ES Engineering Sample
+
+Core Supply Voltage
+LV Vcc: 1.2V
+
+Package Type
+QN48P (QFN48P, 0.4mm)
+MG64P (MBGA64P, 0.5mm)
+
+Logic Density
+4: 4,608 LUTs
+
+DS861-1.8E
+
+59(63)
+
+4 Ordering Information
+
+4.1 Part Naming
+
+Figure 4-2 Part Naming Examples for GW1NSR-4C Devices– ES
+GW1NSR - XX XX
+
+C
+
+XXXXXX ES
+
+Product Series
+GW1NSR
+
+Optional Suffix
+ES Engineering Sample
+
+Core Supply Voltage
+LV Vcc: 1.2V
+
+Package Type
+QN48P (QFN48P, 0.4mm)
+QN48G (QFN48G, 0.4mm)
+MG64P (MBGA64P, 0.5mm)
+
+Logic Density
+4: 4,608 LUTs
+C: ARM Cortex-M3
+
+Figure 4-3 Part Naming Examples for GW1NSR-4 Devices - Production
+
+GW1NSR - XX XX XXXXXX CX/IX
+Product Series
+GW1NSR
+
+Temperature Range
+C Commercial 0 to 85
+I Industrial -40 to 100
+
+Core Supply Voltage
+LV Vcc: 1.2V
+
+Speed Grade
+4 Slowest
+5
+6
+7 Fastest
+Package Type
+QN48P (QFN48P, 0.4mm)
+MG64P (MBGA64P, 0.5mm)
+
+Logic Density
+4: 4,608 LUTs
+
+Figure 4-4 Part Naming Examples for GW1NSR-4C Devices - Production
+GW1NSR - XX XX C
+Product Series
+GW1NSR
+Core Supply Voltage
+LV Vcc: 1.2V
+
+Logic Density
+4: 4,608 LUTs
+C: ARM Cortex-M3
+
+DS861-1.8E
+
+XXXXXX CX/IX
+Temperature Range
+C Commercial 0 to 85
+I Industrial -40 to 100
+Speed Grade
+4 Slowest
+5
+6
+7 Fastest
+Package Type
+QN48P (QFN48P, 0.4mm)
+QN48G (QFN48G, 0.4mm)
+MG64P (MBGA64P, 0.5mm)
+
+60(63)
+
+4 Ordering Information
+
+4.2 Package Markings
+
+4.2 Package Markings
+Gowin’s devices have markings on the their surfaces, as shown in
+Figure 4-5.
+Figure 4-5 Package Marking Examples
+
+[3]
+Part Number
+Date Code
+Lot Number
+
+XXXXXXXXXXXXXXXXX
+YYWW
+LLLLLLLLL
+
+[3]
+Part Number
+Date Code [2]
+Lot Number
+
+XXXXXXXXXXXXXXXXX
+YYWWX
+LLLLLLLLL
+
+[3]
+
+Part Number
+Date Code
+Lot Number
+
+XXXXXXXXXX
+XXXXXXXXXX
+YYWW
+LLLLLLLLL
+
+Part Number [1]
+
+XXXXXXXXXX
+XXXXXXXXXX
+YYWWX
+LLLLLLLLL
+
+Part Number[1]
+
+Part Number [1]
+
+XXXXXXXXXXXXXXXXX
+YYWWXXXX
+LLLLLLLLL
+
+Date Code
+Lot Number
+
+Date Code
+Lot Number
+
+Date Code[2]
+Lot Number
+
+XXXXXXXXXX
+XXXXXXXXXX
+YYWWXXXX
+LLLLLLLLL
+
+Note!
+
+DS861-1.8E
+
+
+
+[1]
+
+The first two lines in the right figure(s) above are both the “Part Number”.
+
+
+
+[2]
+
+The fifth character of the Date Code denotes the version of the device.
+
+
+
+[3]
+
+Whether the package marking bears the Gowin Logo or not depends on the
+package type, package size, and Part Number length. The above figure are only
+examples of the package markings.
+
+61(63)
+
+5About This Manual
+
+5.1 Purpose
+
+5
+
+About This Manual
+
+5.1 Purpose
+This data sheet provides a comprehensive overview of the GW1NSR
+series of FPGA products, including their features, resources, architecture,
+AC/DC characteristics, and ordering details.
+
+5.2 Related Documents
+The latest documents are available at www.gowinsemi.com.
+
+
+
+
+UG863, GW1NSR series of FPGA Products Package & Pinout User
+Guide
+UG864, GW1NSR-4 Pinout
+UG865, GW1NSR-4C Pinout
+
+5.3 Terminology and Abbreviations
+The terminology and abbreviations used in this manual are shown in
+Table 5-1.
+Table 5-1 Terminology and Abbreviations
+Terminology and Abbreviations
+
+Full Name
+
+AHB
+
+Advanced High performance Bus
+
+ALU
+
+Arithmetic Logic Unit
+
+APB
+
+Advanced Peripheral Bus
+
+ARM
+
+Advanced RISC Machine
+
+BSRAM
+
+Block Static Random Access Memory
+
+CFU
+
+Configurable Function Unit
+
+CLS
+
+Configurable Logic Section
+
+CRU
+
+Configurable Routing Unit
+
+DAP
+
+Debug Access Port
+
+DCS
+
+Dynamic Clock Selector
+
+DNL
+
+Differential Nonlinearity
+
+DP
+
+True Dual Port 16K BSRAM
+
+DS861-1.8E
+
+62(63)
+
+5About This Manual
+
+5.4 Support and Feedback
+
+Terminology and Abbreviations
+
+Full Name
+
+DQCE
+
+Dynamic Quadrant Clock Enable
+
+DWT
+
+Data Watchpoint Trace
+
+FPGA
+
+Field Programmable Gate Array
+
+GPIO
+
+Gowin Programmable Input/output
+
+INL
+
+Integral Nonlinearity
+
+IOB
+
+Input/Output Block
+
+ITM
+
+Instrumentation Trace Macrocell
+
+LSB
+
+Least Significant Bit
+
+LUT4
+
+4-input Look-up Table
+
+MG
+
+MBGA
+
+NVIC
+
+Nested Vector Interrupt Controller
+
+PHY
+
+Physical Layer
+
+PLL
+
+Phase-locked Loop
+
+QN
+
+QFN
+
+REG
+
+Register
+
+SAR
+
+Successive Approximation Register
+
+SDP
+
+Semi Dual Port 16K BSRAM
+
+SFDR
+
+Spurious-freeDynamic Range
+
+SINAD
+
+Signal to Noise And Distortion
+
+SoC
+
+System on Chip
+
+SP
+
+Single Port 16K BSRAM
+
+SSRAM
+
+Shadow Static Random Access Memory
+
+TDM
+
+Time Division Multiplexing
+
+Timer
+
+Timer
+
+TimeStamp
+
+TimeStamp
+
+TPIU
+
+Trace Port Interface Unit
+
+UART
+
+Universal Asynchronous Receiver/Transmitter
+
+USB
+
+Universal Serial Bus
+
+Watchdog
+
+Watchdog
+
+5.4 Support and Feedback
+Gowin Semiconductor provides customers with comprehensive
+technical support. If you have any questions, comments, or suggestions,
+please feel free to contact us directly using the information provided below.
+Website: www.gowinsemi.com
+E-mail：support@gowinsemi.com
+
+DS861-1.8E
+
+63(63)
+
+

--- a/definitions/Porting_MicroPython.md
+++ b/definitions/Porting_MicroPython.md
@@ -1,0 +1,252 @@
+ / MicroPython Internals / Porting MicroPython
+
+This is the documentation for the latest development branch of MicroPython and may
+refer to features that are not available in released versions.
+If you are looking for the documentation for a specific release, use the drop-down menu
+on the left and select the desired version.
+
+Porting MicroPython
+The MicroPython project contains several ports to different microcontroller families and
+architectures. The project repository has a ports directory containing a subdirectory for each
+supported port.
+A port will typically contain definitions for multiple “boards”, each of which is a specific piece
+of hardware that that port can run on, e.g. a development kit or device.
+The minimal port is available as a simplified reference implementation of a MicroPython port.
+It can run on both the host system and an STM32F4xx MCU.
+In general, starting a port requires:
+Setting up the toolchain (configuring Makefiles, etc).
+Implementing boot configuration and CPU initialization.
+Initialising basic drivers required for development and debugging (e.g. GPIO, UART).
+Performing the board-specific configurations.
+Implementing the port-specific modules.
+
+Minimal MicroPython firmware
+The best way to start porting MicroPython to a new board is by integrating a minimal
+MicroPython interpreter. For this walkthrough, create a subdirectory for the new port in the
+ports directory:
+
+$ cd ports
+$ mkdir example_port
+
+The basic MicroPython firmware is implemented in the main port file, e.g main.c :
+
+#include "py/builtin.h"
+#include "py/compile.h"
+#include "py/gc.h"
+#include "py/mperrno.h"
+#include "shared/runtime/gchelper.h"
+#include "shared/runtime/pyexec.h"
+// Allocate memory for the MicroPython GC heap.
+static char heap[4096];
+int main(int argc, char **argv) {
+// Initialise the MicroPython runtime.
+mp_cstack_init_with_sp_here(2048);
+gc_init(heap, heap + sizeof(heap));
+mp_init();
+// Start a normal REPL; will exit when ctrl-D is entered on a blank line.
+pyexec_friendly_repl();
+// Deinitialise the runtime.
+gc_sweep_all();
+mp_deinit();
+return 0;
+}
+// Handle uncaught exceptions (should never be reached in a correct C implementation).
+void nlr_jump_fail(void *val) {
+for (;;) {
+}
+}
+// Do a garbage collection cycle.
+void gc_collect(void) {
+gc_collect_start();
+gc_helper_collect_regs_and_stack();
+gc_collect_end();
+}
+// There is no filesystem so stat'ing returns nothing.
+mp_import_stat_t mp_import_stat(const char *path) {
+return MP_IMPORT_STAT_NO_EXIST;
+}
+// There is no filesystem so opening a file raises an exception.
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
+mp_raise_OSError(MP_ENOENT);
+}
+
+We also need a Makefile at this point for the port:
+
+# Include the core environment definitions; this will set $(TOP).
+include ../../py/mkenv.mk
+# Include py core make definitions.
+include $(TOP)/py/py.mk
+include $(TOP)/extmod/extmod.mk
+# Set CFLAGS and libraries.
+CFLAGS += -I. -I$(BUILD) -I$(TOP)
+LIBS += -lm
+# Define the required source files.
+SRC_C = \
+main.c \
+mphalport.c \
+shared/readline/readline.c \
+shared/runtime/gchelper_generic.c \
+shared/runtime/pyexec.c \
+shared/runtime/stdout_helpers.c \
+# Define source files containung qstrs.
+SRC_QSTR += shared/readline/readline.c shared/runtime/pyexec.c
+# Define the required object files.
+OBJ = $(PY_CORE_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+# Define the top-level target, the main firmware.
+all: $(BUILD)/firmware.elf
+# Define how to build the firmware.
+$(BUILD)/firmware.elf: $(OBJ)
+$(ECHO) "LINK $@"
+$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+$(Q)$(SIZE) $@
+# Include remaining core make rules.
+include $(TOP)/py/mkrules.mk
+
+Remember to use proper tabs to indent the Makefile.
+
+MicroPython Configurations
+After integrating the minimal code above, the next step is to create the MicroPython
+configuration files for the port. The compile-time configurations are specified in
+mpconfigport.h
+
+and additional hardware-abstraction functions, such as time keeping, in
+
+mphalport.h .
+
+The following is an example of an mpconfigport.h file:
+
+#include <stdint.h>
+// Python internal features.
+#define MICROPY_ENABLE_GC
+#define MICROPY_HELPER_REPL
+#define MICROPY_ERROR_REPORTING
+#define MICROPY_FLOAT_IMPL
+
+(1)
+(1)
+(MICROPY_ERROR_REPORTING_TERSE)
+(MICROPY_FLOAT_IMPL_FLOAT)
+
+// Fine control over Python builtins, classes, modules, etc.
+#define MICROPY_PY_ASYNC_AWAIT
+(0)
+#define MICROPY_PY_BUILTINS_SET
+(0)
+#define MICROPY_PY_ATTRTUPLE
+(0)
+#define MICROPY_PY_COLLECTIONS
+(0)
+#define MICROPY_PY_MATH
+(0)
+#define MICROPY_PY_IO
+(0)
+#define MICROPY_PY_STRUCT
+(0)
+// Type definitions for the specific machine.
+typedef long mp_off_t;
+// We need to provide a declaration/definition of alloca().
+#include <alloca.h>
+// Define the port's name and hardware.
+#define MICROPY_HW_BOARD_NAME "example-board"
+#define MICROPY_HW_MCU_NAME
+"unknown-cpu"
+#define MP_STATE_PORT MP_STATE_VM
+
+This configuration file contains machine-specific configurations including aspects like if
+different MicroPython features should be enabled e.g. #define MICROPY_ENABLE_GC (1) . Making
+this Setting (0) disables the feature.
+Other configurations include type definitions, root pointers, board name, microcontroller
+name etc.
+Similarly, an minimal example mphalport.h file looks like this:
+
+static inline void mp_hal_set_interrupt_char(char c) {}
+
+Support for standard input/output
+MicroPython requires at least a way to output characters, and to have a REPL it also requires
+a way to input characters. Functions for this can be implemented in the file mphalport.c , for
+example:
+
+#include <unistd.h>
+#include "py/mpconfig.h"
+// Receive single character, blocking until one is available.
+int mp_hal_stdin_rx_chr(void) {
+unsigned char c = 0;
+int r = read(STDIN_FILENO, &c, 1);
+(void)r;
+return c;
+}
+// Send the string of given length.
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+int r = write(STDOUT_FILENO, str, len);
+(void)r;
+}
+
+These input and output functions have to be modified depending on the specific board API.
+This example uses the standard input/output stream.
+
+Building and running
+At this stage the directory of the new port should contain:
+
+ports/example_port/
+├── main.c
+├── Makefile
+├── mpconfigport.h
+├── mphalport.c
+└── mphalport.h
+
+The port can now be built by running make (or otherwise, depending on your system).
+If you are using the default compiler settings in the Makefile given above then this will create
+an executable called build/firmware.elf which can be executed directly. To get a functional
+REPL you may need to first configure the terminal to raw mode:
+
+$ stty raw opost -echo
+$ ./build/firmware.elf
+
+That should give a MicroPython REPL. You can then run commands like:
+
+MicroPython v1.13 on 2021-01-01; example-board with unknown-cpu
+>>> import sys
+>>> sys.implementation
+('micropython', (1, 13, 0))
+>>>
+
+Use Ctrl-D to exit, and then run reset to reset the terminal.
+
+Adding a module to the port
+To add a custom module like myport , first add the module definition in a file modmyport.c :
+
+#include "py/runtime.h"
+static mp_obj_t myport_info(void) {
+mp_printf(&mp_plat_print, "info about my port\n");
+return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(myport_info_obj, myport_info);
+static const mp_rom_map_elem_t myport_module_globals_table[] = {
+{ MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_myport) },
+{ MP_ROM_QSTR(MP_QSTR_info), MP_ROM_PTR(&myport_info_obj) },
+};
+static MP_DEFINE_CONST_DICT(myport_module_globals, myport_module_globals_table);
+const mp_obj_module_t myport_module = {
+.base = { &mp_type_module },
+.globals = (mp_obj_dict_t *)&myport_module_globals,
+};
+MP_REGISTER_MODULE(MP_QSTR_myport, myport_module);
+
+You will also need to edit the Makefile to add modmyport.c to the SRC_C list, and a new line
+adding the same file to SRC_QSTR (so qstrs are searched for in this new file), like this:
+
+SRC_C = \
+main.c \
+modmyport.c \
+mphalport.c \
+...
+SRC_QSTR += modmyport.c
+
+If all went correctly then, after rebuilding, you should be able to import the new module:
+
+>>> import myport
+>>> myport.info()
+info about my port
+>>>
+
+

--- a/definitions/Tang_Nano_4K.md
+++ b/definitions/Tang_Nano_4K.md
@@ -1,0 +1,293 @@
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Characteristic：
+
+
+Main Chip : GW1NSR-LV4C with arm Cortex-M3 hard core
+
+
+
+Embedded FPGA logic module unit (4608 lut4)
+
+
+
+SOC device realizes the seamless connection between programmable
+logic device and embedded processor
+
+
+
+Onboard usb-jtag debugger
+
+
+
+On board HDMI connector and its circuit
+
+
+
+Onboard camera connector (DVP interface)
+
+
+
+Onboard wson8 pad (32Mbit nor flash default)
+
+深圳矽速科技有限公司
+
+1
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Update record of this document
+V1.0
+
+Edited on August 7, 2021; Original document
+
+Hardware overview
+• Cortex-M3 32-bit RISC kernel；ARM3v7M Architecture
+Hard core processor
+
+• Maximum operating frequency : 80MHz
+• Hardware division and single cycle multiplication
+• 26 interrupts with 8 priorities
+
+Logic cells
+(4-input LUT4)
+Register(FF)
+
+Quantity：4608
+Quantity：3456
+
+Block static random
+access memory
+
+Capacity：180K
+
+B-SRAM(bits)
+18 x 18 Multiplier
+
+Quantity：16
+
+User flash memory
+
+Embedded 256Kb storage space
+
+HyperRAM
+
+Capacity：64Mb ； Bit width：8bits
+• 2 PLL
+
+Flexible PLL resources
+
+• Realize the frequency doubling, frequency division and phase shift
+• Global clock network resources
+
+Display screen
+interface
+
+HDMI connector and its circuit
+
+Camera connector
+
+24P 0.5mm spacing FPC connector (common DVP camera sequence)
+
+Debugger
+
+On board bl702 chip provides JTAG debugging function for GW1NSR
+
+IO
+
+•
+
+Support 4mA, 8mA, 16mA, 24mA and other driving capabilities
+
+•
+
+Independent bus keeper, pull-up / pull-down resistor and open drain
+
+output options are provided for each I/O
+• Support Mipi interface
+
+Push button
+
+2 programmable Push buttons
+
+LED
+
+On board 1 programmable LED
+
+Number of GPIO
+
+深圳矽速科技有限公司
+
+38
+
+2
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Software overview
+IDE
+
+Support Gowin IDE(Version>1.9.7) ；Support Gowin Synthesis
+
+Floating License
+
+45.33.107.56:10559
+
+Off-line License
+IDE
+MCU development
+documents
+GOAI brief
+introduction
+GOAI Official project
+Sipeed Reference
+example
+
+Send application email to support@sipeed.com
+Example of mail title ：【Apply Tang Lic】MAC: xxxxxx
+http://www.gowinsemi.com.cn/faq.aspx
+http://www.gowinsemi.com.cn/down.aspx?TypeId=317&Id=394
+http://www.gowinsemi.com.cn/down.aspx?TypeId=666&Id=757
+https://github.com/gowinsemi/GoAI
+https://github.com/sipeed/TangNano-4K-example
+
+Working conditions
+Power supply
+demand
+Temperature rise
+Operating ambient
+temperature range
+
+深圳矽速科技有限公司
+
+TYPE-C connector：5V±10% 0.5A
+<30K
+-10℃ ~ 65℃
+
+3
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Appearance drawing
+
+深圳矽速科技有限公司
+
+4
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Functional annotation
+
+深圳矽速科技有限公司
+
+5
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Dimension information
+Length
+
+60.0 mm
+
+Width
+
+22.86mm
+
+Thickness
+
+Please check the 3D drawing
+
+深圳矽速科技有限公司
+
+6
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+Matters needing attention
+Please pay attention to avoid static electricity hitting PCBA;
+ESD protection
+
+Please release the static electricity from the handle before contacting
+PCBA
+The working voltage of each GPIO has been marked in the
+
+Tolerance voltage
+
+schematic . Please do not let the actual working voltage of GPIO
+exceed the rated value, otherwise it will cause permanent damage to
+PCBA
+
+FPC connector
+Plugging
+
+When connecting FPC flexible cable, please ensure that the cable is
+completely inserted into the cable without offset；
+Please disconnect the power completely before plugging in and out
+the camera
+Please avoid any liquid or metal touching the pads of components
+
+Avoid short circuit
+
+on PCBA during power on, otherwise it will cause short circuit and
+burn PCBA
+• JTAG : IOT2A/IOT2B/IOT3A/IOT3B/IOT4B
+
+Please avoid using these GPIO.
+
+• MODE : IOT7A
+• DONE : IOT5B
+If you must use these GPIO, please read the following documents:
+<Ug292-1.0 schematic diagram instruction manual>
+
+Resources
+Official website
+
+www.sipeed.com
+
+Github
+
+https://github.com/Sipeed
+
+BBS
+
+http://bbs.sipeed.com
+
+Wiki
+
+wiki.sipeed.com
+
+Sipeed Model platform
+
+https://maixhub.com/
+
+SDK /HDK Relevant information
+
+https://dl.sipeed.com/
+
+E-mail
+(Technical support and business
+
+support@sipeed.com
+
+cooperation)
+
+深圳矽速科技有限公司
+
+7
+
+Sipeed Tang Nano 4K Datasheet v1.0
+
+免责声明和版权声明
+本文档中的信息（包括 URL 地址）如有更改，恕不另行通知。
+该文档由 Sipeed 提供，不附带任何形式的担保，包括任何适销
+性担保，以及其他地方提及的任何提案，规范或样本。 本文
+档不构成责任，包括使用本文档中的信息侵犯任何专利权。
+Copyrights © 2021 Sipeed Limited. All rights reserved.
+
+深圳矽速科技有限公司
+
+8
+
+

--- a/definitions/Tang_Nano_4K_Pinout.md
+++ b/definitions/Tang_Nano_4K_Pinout.md
@@ -1,0 +1,3 @@
+# Tang Nano 4K Pinout
+
+![Tang Nano 4K Pinout](Tang_Nano_4K_Pinout.png)

--- a/definitions/Tang_Nano_4K_Sipeed_Wiki.md
+++ b/definitions/Tang_Nano_4K_Sipeed_Wiki.md
@@ -1,0 +1,122 @@
+Next-Gen 4K AI Camera MaixCAM2 is now crowdfunding! 10X faster than K230 in yolo task!
+
+Tang Nano 4K
+2025-02-11
+
+Edit this page
+
+Edit on 2022.08.16
+
+1. Introduction
+Tang Nano 4K is a development board designed based on Gowin little-bee GW1NSR-LV4C
+FPGA chip. The board is equipped with camera interface and HDMI interface. There is also an
+onboard USG-JTAG debugger, which make it convenient for users to use. Its Cortex-M3
+hardcore can help users study mcu.
+
+2. Specs
+The sheet below shows difference with previous product
+
+FPGA chip
+
+GW1N-1-LV
+
+GW1NSR-LV4C
+
+logic units
+
+1152
+
+4608
+
+Register
+
+864
+
+3456
+
+Hard processor
+
+none
+
+ARM Cortex M3
+
+Block SRAM(bits)
+
+72K
+
+180K
+
+User flash(bits)
+
+96K
+
+256K
+
+Number of PLL
+
+1
+
+2
+
+Number of I/O Bank
+
+4
+
+4
+
+Number of users I/O
+
+41
+
+44
+
+x
+
+Screen interface
+
+40P RGB LCD interface
+
+HDMI interface
+
+camera interface
+
+None
+
+DVP interface
+
+Size
+
+58.4mm*21.3mm
+
+60mm*22.86mm
+
+2.1. Pinmap
+
+3. Development software
+Visit install ide to setup your programming environment.
+
+4. Burn firmware
+Tang Nano 4K uses the onboard BL702 for jtag, with which to burn bitstream.
+Run the Programmer in Gowin IDE to download firmware into FPGA.
+
+5. Informations
+Datasheet
+Schematic
+Bit number map
+Dimensional drawing
+3D File
+
+hip Manual
+Examples
+
+6. Addition
+1. If you have trouble with this board, you can join our telegram (t.me/sipeed) or contact us
+on twitter ( https://twitter.com/SipeedIO ). Leaving message below is also OK.
+2. Visit Tang questions first if you have any trouble.
+3. Debugging Cortex-M3, we suggest to use serial-port debug way. If you are excellent
+enough you can try other ways to debug it.
+4. THe HDMI ports are multiplexed as IO and routed to the pin headers. The actual results
+of the IO which are multiplexed with HDMI pins on the pin headers may not be consistent
+with what you want because of the external pull up.
+
+

--- a/definitions/UG290_Gowin_FPGA_Programming_Guide.md
+++ b/definitions/UG290_Gowin_FPGA_Programming_Guide.md
@@ -1,0 +1,5742 @@
+Gowin FPGA Products
+
+Programming and Configuration Guide
+
+UG290-2.3E, 02/07/2021
+
+Copyright©2021 Guangdong Gowin Semiconductor Corporation. All Rights Reserved.
+No part of this document may be reproduced or transmitted in any form or by any denotes,
+electronic, mechanical, photocopying, recording or otherwise, without the prior written
+consent of GOWINSEMI.
+Disclaimer
+GOWINSEMI®, LittleBee®, Arora, and the GOWINSEMI logos are trademarks of
+GOWINSEMI and are registered in China, the U.S. Patent and Trademark Office, and other
+countries. All other words and logos identified as trademarks or service marks are the
+property of their respective holders, as described at www.gowinsemi.com. GOWINSEMI
+assumes no liability and provides no warranty (either expressed or implied) and is not
+responsible for any damage incurred to your hardware, software, data, or property resulting
+from usage of the materials or intellectual property except as outlined in the GOWINSEMI
+Terms and Conditions of Sale. All information in this document should be treated as
+preliminary. GOWINSEMI may make changes to this document at any time without prior
+notice. Anyone relying on this documentation should contact GOWINSEMI for the current
+documentation and errata.
+
+Revision History
+Date
+
+Version
+
+Description
+
+4/17/2017
+
+1.00E
+
+5/31/2017
+
+1.01E
+
+10/13/2017
+
+1.02E
+
+Initial version published.
+ Configuration mode and value of different supported
+device updated;
+ RECONFIG N notes during programming built-in Flash
+updated.
+Description of reusing pins updated.
+
+3/16/2018
+
+1.03E
+
+8/8/2018
+
+1.04E
+
+1/8/2019
+
+1.05E
+
+8/16/2019
+
+1.06E
+
+5/15/2020
+
+2.0E
+
+8/20/2020
+
+2.1E
+
+10/30/2020
+
+2.2E
+
+GW1NS programming and configuration description added.
+ The description of configuration process when Flash is
+empty updated;
+ Operation procedures for multiple configurations
+updated;
+ When MODE[0]=1, JTAG pins reuse description updated;
+ The programming features of B version devices updated;
+ Configuration notes and the timing for different
+configuration modes added.
+ The configuration timing and parameters for SERIAL
+mode added;
+ The description of power supply requirements deleted.
+ Power up description and configuration flow added;
+ The description of File Size Configuration modified.
+ The note of JTAGSEL_N used as IO added.
+ GW1N(R)-2/GW1N(R)-2B/GW1N(R)-6 removed;
+ Configuration mode description optimized.
+ JTAG Configuration added;
+ SSPI Configuration added;
+ AES Programming added;
+Configuration File Loading Time added.
+
+02/07/2021
+
+2.3E
+
+I2C Configuration added.
+
+Contents
+
+Contents
+Contents ............................................................................................................... i
+List of Figures .................................................................................................... iii
+List of Tables ....................................................................................................... v
+1 About This Guide ............................................................................................. 1
+1.1 Purpose .............................................................................................................................. 1
+1.2 Related Documents ............................................................................................................ 1
+1.3 Terminology and Abbreviations .......................................................................................... 1
+1.4 Support and Feedback ....................................................................................................... 2
+
+2 Glossary ........................................................................................................... 3
+3 Configuration Modes ....................................................................................... 5
+®
+
+3.1 LittleBee Family of FPGA Products .................................................................................. 5
+3.2 Arora Family of FPGA Products ......................................................................................... 6
+
+4 Configuration Pin............................................................................................. 8
+4.1 Configuration Pin List and Reuse Options ......................................................................... 8
+4.1.1 Configuration Pin List ...................................................................................................... 8
+4.1.2 Configuration Pin Multiplexing ......................................................................................... 9
+4.2 Configuration Pin Function and Application ..................................................................... 11
+
+5 Configuration Mode Introduction ................................................................. 16
+5.1 Configuration Notes .......................................................................................................... 16
+5.2 JTAG Configuration .......................................................................................................... 19
+5.2.1 JTAG Configuration Mode Pins ..................................................................................... 20
+5.2.2 Connection Diagram for the JTAG Configuration Mode ................................................ 21
+5.2.3 JTAG Configuration Timing ........................................................................................... 22
+5.2.4 JTAG Configuration Process ......................................................................................... 23
+®
+
+5.3 AUTO BOOT Configuration (Supported by LittleBee Family Only) ................................ 47
+5.4 SSPI ................................................................................................................................. 49
+5.4.1 SSPI Mode Pins ............................................................................................................ 49
+5.4.2 SSPI Configuration Timing ............................................................................................ 50
+5.4.3 Configuration Instruction ............................................................................................... 50
+5.4.4 Connection Diagram for SSPI Configuration Mode ...................................................... 54
+5.4.5 Multiple FPGA Connection View in SSPI Mode ............................................................ 56
+
+UG290-2.3E
+
+i
+
+Contents
+
+5.5 MSPI ................................................................................................................................. 56
+®
+
+5.6 DUAL BOOT Configuration (Supported by LittleBee Family Only) ................................ 62
+5.7 CPU Mode ........................................................................................................................ 64
+5.7.1 Configuration Timing ..................................................................................................... 65
+5.8 SERIAL Mode ................................................................................................................... 65
+2
+
+5.9 I C Mode ........................................................................................................................... 67
+
+6 Bitstream File Configuration......................................................................... 70
+6.1 Configuration Options ....................................................................................................... 70
+6.2 Configuration Data Encryption (Supported by Arora Family only) .................................... 71
+6.2.1 Definition ....................................................................................................................... 71
+6.2.2 Enter Encryption KEY.................................................................................................... 72
+6.2.3 Enter the Decrypt Key ................................................................................................... 72
+6.2.4 Programming Operation ................................................................................................ 73
+6.2.5 Programming Flow ........................................................................................................ 75
+6.3 Configuration File Size ..................................................................................................... 78
+6.4 Configuration File Loading Time ...................................................................................... 79
+
+7 Safety Precautions ........................................................................................ 83
+8 Boundary Scan .............................................................................................. 85
+9 SPI Flash Selection........................................................................................ 87
+
+UG290-2.3E
+
+ii
+
+List of Figures
+
+List of Figures
+Figure 4-1 Configuring Pin Reuse...................................................................................................... 11
+Figure 4-2 MCLK Frequency Setting ................................................................................................. 14
+Figure 5-1 Recommended Pin Connection ........................................................................................ 18
+Figure 5-2 Power Recycle Timing ...................................................................................................... 18
+Figure 5-3 Trigger Timing ................................................................................................................... 19
+Figure 5-4 Connection Diagram for JTAG Configuration Mode ......................................................... 21
+Figure 5-5 Connection Diagram of JTAG Daisy-Chain Configuration Mode ..................................... 22
+Figure 5-6 JTAG Configuration timing ................................................................................................ 22
+Figure 5-7 TAP State Machine ........................................................................................................... 23
+Figure 5-8 Instruction Register Access Timing .................................................................................. 24
+Figure 5-9 Data Register Access Timing ........................................................................................... 24
+Figure 5-10 Read Machine Flow Chart in ID Code State .................................................................. 26
+Figure 5-11 The Access Timing of Read ID Code Instruction- 0x11 .................................................. 26
+Figure 5-12 Read ID Code Data Register Access Timing ................................................................. 27
+Figure 5-13 SRAM Configuration Flow .............................................................................................. 28
+Figure 5-14 Process of reading SRAM .............................................................................................. 30
+Figure 5-15 The Embedded Flash Erasing process of T Technology ................................................ 32
+Figure 5-16 The Embedded Flash Erasing process of S Technology ............................................... 34
+Figure 5-17 Process of Programming Internal Flash View ................................................................ 36
+Figure 5-18 X-page Programming ..................................................................................................... 37
+Figure 5-19 Y-page Programming ...................................................................................................... 38
+Figure 5-20 Process of Reading Internal Flash ................................................................................. 39
+Figure 5-21 Process of Reading a Y-page ......................................................................................... 40
+Figure 5-22 GW1N-4 Background Programming Flow ...................................................................... 41
+Figure 5-23 Transfer JTAG Instruction Sample & Extest Flow Chart ................................................ 42
+Figure 5-24 Connection Diagram of JTAG Programming External Flash .......................................... 43
+Figure 5-25 Process View of Programming SPI Flash SPI................................................................ 43
+Figure 5-26 Timing Diagram of Sending 0x06 via GW2A series JTAG Simulating SPI ..................... 44
+Figure 5-27 Timing Diagram of Sending 0x06 via GW1N series JTAG Simulating SPI .................... 44
+Figure 5-28 Process of Use Boundary Scan Mode To Program SPI Flash ....................................... 45
+Figure 5-29 Connection Diagram of Daisy-Chain .............................................................................. 47
+Figure 5-30 SSPI Configuration Timing ............................................................................................. 50
+
+UG290-2.3E
+
+iii
+
+List of Figures
+
+Figure 5-31 Read ID Code Timing ..................................................................................................... 51
+Figure 5-32 Write Enable (0x15) Timing ............................................................................................ 52
+Figure 5-33 Write Disable(0x3A00) Timing ........................................................................................ 52
+Figure 5-34 Write Data (0x3B) Timing ............................................................................................... 53
+Figure 5-35 SSPI Configuration Mode Connection Diagram .................................................................. 54
+Figure 5-36 Connection Diagram of Programming External Flash via SSPI ..................................... 54
+Figure 5-37 The Flow of Programming External Flash via SSPI ....................................................... 55
+Figure 5-38 Multiple FPGA Connection Diagram 1............................................................................ 56
+Figure 5-39 Multiple FPGA Connection Diagram 2............................................................................ 56
+Figure 5-40 Connection Diagram for MSPI Configuration Mode ....................................................... 58
+Figure 5-41 Connection Diagram of JTAG Programming External Flash .......................................... 58
+Figure 5-42 Input the Start address for the Next BitStream .............................................................. 59
+Figure 5-43 Set the Programming Address for the External Flash .................................................... 60
+Figure 5-44 Connection Diagram for Configuring Multiple FPGAs via Single Flash ......................... 61
+Figure 5-45 MSPI Download Timing .................................................................................................. 61
+Figure 5-46 Multiple FPGA Connection Diagram in MSPI Configuration Mode ................................ 62
+Figure 5-47 Dual Boot Flow Chart ..................................................................................................... 63
+Figure 5-48 Connection Diagram for CPU Mode ............................................................................... 65
+Figure5-49 CPU Mode Configuration Timing ..................................................................................... 65
+Figure 5-50 Connection Diagram for SERIAL Mode .......................................................................... 66
+Figure 5-51 SERIAL Configuration Timing ......................................................................................... 66
+2
+
+Figure 5-52 Connection Diagram for I C Mode ................................................................................. 68
+2
+
+Figure 5-53 I C Mode Timing ............................................................................................................. 68
+Figure 6-1 Configuration Options ....................................................................................................... 71
+Figure 6-2 Encryption Key Setting Method ........................................................................................ 72
+Figure 6-3 Setting the Decryption Key ............................................................................................... 73
+Figure 6-4 AES Security Configure .................................................................................................... 74
+Figure 6-5 Prepare ............................................................................................................................. 75
+Figure6-6 Read AES Key Flow .......................................................................................................... 76
+Figure 6-7 Program AES Key Flow .................................................................................................... 77
+Figure 6-8 Lock AES Key Flow .......................................................................................................... 78
+Figure 6-9 Bitstream Format generation ............................................................................................ 79
+Figure 8-1 Boundary Scan Operation Schematic Diagram ............................................................... 86
+
+UG290-2.3E
+
+iv
+
+List of Tables
+
+List of Tables
+Table 1-1 Abbreviations and Terminology .......................................................................................... 1
+Table 2-1 Glossary ............................................................................................................................. 3
+Table 3-1 Configuration Modes .......................................................................................................... 6
+Table 3-2 Configuration Modes .......................................................................................................... 7
+Table 4-1 Configuration Pin List ......................................................................................................... 8
+Table 4-2 Pin Reuse Options ............................................................................................................. 10
+Table 4-3 Pin Function ....................................................................................................................... 11
+Table 5-1 Timing Parameters for Cycling Power and RECONFIG_N Trigger ................................... 19
+Table 5-2 Timing Parameters for Power-on again and RECONFIG_N Triggering (Arora Family) .... 19
+Table 5-3 Pin Description in JTAG Configuration Mode ..................................................................... 20
+Table 5-4 JTAG Configuration Timing Parameters ............................................................................ 22
+Table 5-5 Gowin FPGA IDCODE ....................................................................................................... 25
+Table 5-6 Change of TDI and TMS Value in The Process of Sending Instructions ........................... 25
+Table 5-7 Count of Address and Length of One Address .................................................................. 29
+Table 5-8 TCK Frequency Requirements for JTAG ........................................................................... 31
+Table 5-9 Readback-pattern / Autoboot-pattern ................................................................................. 35
+Table 5-10 Pin State ........................................................................................................................... 44
+Table 5-11 Status Register Definition ................................................................................................. 46
+Table 5-12 SSPI Mode Pins ............................................................................................................... 49
+Table 5-13 SSPI Configuration Timing Parameters ........................................................................... 50
+Table 5-14 Configuration Instruction .................................................................................................. 51
+Table 5-15 Pin Description in JTAG Configuration Mode ................................................................... 57
+Table 5-16 MSPI Configuration Timing Parameters........................................................................... 62
+Table 5-17 CPU Mode Pins ................................................................................................................ 64
+Table 5-18 Pin Definition in SERIAL Configuration Mode .................................................................. 66
+Table 5-19 SERIAL Configuration Timing Parameters ....................................................................... 67
+Table 5-20 Pin Definition in SERIAL Configuration Mode .................................................................. 67
+2
+
+Table 5-21 I C Configuration Timing Parameters .............................................................................. 68
+Table 6-1 Gowin FPGA Products Configuration File Size (Max.) ...................................................... 79
+Table 6-2 Loading Frequency of Config File ...................................................................................... 80
+Table 6-3 Loading Time in MSPI Mode .............................................................................................. 82
+Table 6-4 Loading Time in Autoboot Mode ........................................................................................ 82
+
+UG290-2.3E
+
+v
+
+List of Tables
+
+Table 9-1 SPI Flash Operation Instruction ......................................................................................... 87
+
+UG290-2.3E
+
+vi
+
+1 About This Guide
+
+1.1 Purpose
+
+1
+
+About This Guide
+
+1.1 Purpose
+This guide mainly introduces general features and functions on
+programming and configuration of LittleBee® family devices and Arora
+family devices. It helps users to use Gowin FPGA products to their full
+potential.
+
+1.2 Related Documents
+The latest user guides are available on the GOWINSEMI Website. You
+can find the related documents at www.gowinsemi.com:
+ DS100, GW1N series of FPGA Products Data Sheet
+ DS102, GW2A series of FPGA Products Data Sheet
+ DS117, GW1NR series of FPGA Products Data Sheet
+ DS226, GW2AR series of FPGA Products Data Sheet
+ DS961, GW2ANR series of FPGA Products Data Sheet
+ DS821, GW1NS series of FPGA Products Data Sheet
+ DS841, GW1NZ series of FPGA Products Data Sheet
+ DS861, GW1NSR series of FPGA Products Data Sheet
+ DS871, GW1NSE series of FPGA Products Data Sheet
+ DS881, GW1NSER series of FPGA Products Data Sheet
+ DS891, GW1NRF series of FPGA Products Data Sheet
+
+1.3 Terminology and Abbreviations
+The terminology and abbreviations used in this manual are as shown in
+Table 1-1.
+Table 1-1 Abbreviations and Terminology
+
+UG290-2.3E
+
+Terminology and Abbreviations
+
+Full Name
+
+LUT
+
+Look-up Table
+
+FPGA
+
+Field Programmable Gate Array
+
+JTAG
+
+Joint Test Action Group
+
+GPIO
+
+General Purpose Input Output
+
+1(87)
+
+1 About This Guide
+
+1.4 Support and Feedback
+
+Terminology and Abbreviations
+
+Full Name
+
+SPI
+
+Serial Peripheral Interface
+
+SRAM
+
+Static Random Access Memory
+
+MSPI
+
+Master Serial Peripheral Interface
+
+SSPI
+
+Slave Serial Peripheral Interface
+
+CPU
+
+Central Processing Unit
+
+IEEE
+
+Institute of Electrical and Electronics Engineers
+
+ID
+
+Identification
+
+CRC
+
+Cyclic Redundancy Check
+
+FS file
+
+Fuses file
+
+Configuration
+
+Configuration
+
+Configuration Data
+
+Configuration Data
+
+Bitstream
+
+Bitstream Data
+
+Configuration Mode
+
+Configuration Mode
+
+EFlash/EmbFlash
+
+Embedded Flash
+
+Internal Flash
+
+Internal Flash
+
+Programming
+
+Programming
+
+Edit Mode
+
+Edit Mode
+
+User Mode
+
+User Mode
+
+Background Programming
+
+Embedded Flash Background Programming
+
+LSB
+
+Least Significant Bit
+
+MSB
+
+Most Significant Bit
+
+TAP
+
+Test Access Port
+
+Security Bit
+
+Security Bit
+
+Bscan
+
+Boundary Scan
+
+2
+
+I2C (I C、IIC)
+
+Inter-Integrated Circuits
+
+SCL
+
+Serial Clock
+
+SDA
+
+Serial Data
+
+1.4 Support and Feedback
+Gowin Semiconductor provides customers with comprehensive
+technical support. If you have any questions, comments, or suggestions,
+please feel free to contact us directly by the following ways.
+Website: www.gowinsemi.com
+E-mail:support@gowinsemi.com
+
+UG290-2.3E
+
+2(87)
+
+2 Glossary
+
+2
+
+Glossary
+
+This chapter presents an overview of the terms that are commonly
+used in the process of programming and configuring of Gowin FPGA
+products to help users get familiar with the related concepts.
+Table 2-1 Glossary
+
+Glossary
+
+Meaning
+Write bitstream data generated by Gowin software to FPGA
+Program
+on-chip Flash or off-chip SPI Flash that is connected to the
+FPGA.
+Load bitstream data generated by Gowin software to the
+Configure
+FPGA SRAM via external interfaces or on-chip Flash.
+In addition to the generic JTAG configuration mode, Gowin
+FPGA products support additional configurations, including
+AUTO BOOT configuration, DUAL BOOT configuration, MSPI
+GowinCONFIG
+configuration, SSPI configuration, SERIAL configuration, and
+CPU configuration. How many GowinCONFIG configuration
+modes each device supports depend on the device model and
+package.
+A representation of the three MODE pin values associated
+MODE[2:0]
+with GowinCONFIG.
+AUTO BOOT
+FPGA loads bitstream data into the SRAM from an embedded
+Configuration
+Flash. Only non-volatile devices support this mode.
+Two bitstream files are stored in embedded Flash and
+external Flash separately. Switch to the embedded Flash if the
+DUAL BOOT Configuration
+external Flash fails to configure. Only non-volatile devices
+support this mode.
+As a master, FPGA is configured by reading bitstream from
+MSPI Configuration
+the external Flash via the SPI interface automatically.
+As a slave, FPGA is configured by the external master writing
+SSPI Configuration
+bitstream via the SPI interface.
+As a slave, FPGA is configured by the external master writing
+SERIAL Configuration
+bitstream via the serial interface.
+As a slave, FPGA is configured by the external master writing
+CPU Configuration
+bitstream via the parallel interface (8-bit).
+UG290-2.3E
+
+3(87)
+
+2 Glossary
+
+Glossary
+I2C Configuration
+
+MULTI BOOT
+Configuration
+
+Remote Upgrade
+
+Daisy Chain
+
+User Mode
+
+Edit Mode
+
+ID CODE
+USER CODE
+
+Security Bit
+
+Encryption
+
+UG290-2.3E
+
+Meaning
+As a slave, FPGA is configured by the external master writing
+bitstream via the I2C interface.
+The derivative concept of MSPI, it refers to that FPGA reads
+bitstream data from different addresses of external Flash. The
+loading address of the latter bitstream data is written in
+previous bitstream data and the configuration is completed by
+triggering RECONFIG_N to switch the data stream file under
+the condition that the device power is on. FPGA products that
+support MSPI all support this mode.
+After FPGA starts to work, if an upgrade is required, first write
+bitstream to embedded or external Flash through remote
+operation, and then FPGA reads the external Flash by
+triggering RECONFIG_N or powering up again to complete
+the configuration.
+FPGA devices are connected sequentially in a serial way.
+Devices can be configured from the head of the chain in
+sequence according to the connection order, and data can
+only be transmitted between adjacent devices.
+Hands over control to users when the FPGA configuration has
+been completed. Only in user mode, configuration pins can be
+reused as GPIOs (Gowin Programmable I/O).
+FPGA can be programmed and configured in this mode.
+All configuration pins cannot be reused as GPIOs. The output
+of all GPIOs is high-impedance state, except transparent
+transmission.
+Identification for the Gowin FPGA device. Each series of
+devices has a different number.
+Used to identify the FPGA device that used. The user code
+can be written to the FPGA device through Gowin
+programmer. Up to 32-bit can be supported.
+A special design for the configuration data security of Gowin
+FPGA product. After you write the bitstream with security bit to
+the device, no one will be able to read back the data. Gowin
+software sets a security bit for the bitstream data of all FPGA
+products by default.
+The Arora family of FPGA products supports this feature. After
+the encrypted bitstream is written to FPGA, the device will
+match the pre-stored key automatically, and then decrypt and
+wake up the device after successful matching. The device
+cannot work if matching fails.
+
+4(87)
+
+3 Configuration Modes
+
+3.1 LittleBee® Family of FPGA Products
+
+3
+
+Configuration Modes
+
+3.1 LittleBee® Family of FPGA Products
+Besides the JTAG configuration mode that is commonly used in the
+industry, the LittleBee® Family of FPGA products also support
+GOWINSEMI's own configuration mode: GowinCONFIG. GowinCONFIG
+configuration modes that are available and supported for each device
+depend on the device model and package. All non-volatile devices support
+JTAG and AUTO BOOT modes. Up to six configuration modes are
+supported, as shown in Table 3-1.
+
+UG290-2.3E
+
+5(87)
+
+3 Configuration Modes
+
+3.2 Arora Family of FPGA Products
+
+Table 3-1 Configuration Modes
+Configuration Modes
+
+MODE[2:0][1]
+
+Description
+
+XXX
+
+The LittleBee® Family of FPGA products
+are configured via JTAG interface by
+external Host.
+
+AUTO
+BOOT
+
+000
+
+FPGA reads data from embedded Flash
+for configuration
+
+I2C[6]
+
+100
+
+External Host configure FPGA products
+via the I2C interface.
+
+SSPI
+
+001
+
+External Host configure FPGA products
+of LittleBee® Family via SPI interface.
+
+MSPI
+
+010
+
+As Master, FPGA reads data from
+external Flash (or other devices) via the
+SPI interface[3].
+
+DUAL
+BOOT[4]
+
+110
+
+FPGA reads data from external Flash
+first and if the external Flash
+configuration fails, it reads from the
+Internal Flash.
+
+SERIAL[5]
+
+101
+
+External Host configure FPGA products
+of LittleBee® Family via DIN interface.
+
+CPU[5]
+
+111
+
+External Host configure FPGA products
+of LittleBee® Family via DBUS interface.
+
+[2]
+
+JTAG
+
+GowinCONFIG
+
+Note!
+
+
+
+
+
+
+
+
+[1] The unbound mode pins are grounded by default;
+[2] The JTAG configuration mode is independent of MODE value;
+[3] The SPI interfaces of the SSPI and MSPI modes are independent of each other;
+[4] Currently GW1N(R)-4 / GW1N(R)-4B do not support DUAL BOOT;
+[5] The CPU configuration mode and SERIAL configuration mode share SCLK,
+WE_N and CLKHOLD_N. The data bus pins for the CPU configuration mode share
+pins with MSPI and SSPI configuration modes.
+2
+[6] I C is only supported in some devices.
+
+Note!
+For details about configuration pins, pin reuse, and pin functions and application, please
+refer to 4 Configuration Pin.
+
+3.2 Arora Family of FPGA Products
+Besides the JTAG configuration mode that is commonly used in the
+industry, the Arora Family of FPGA products also support GOWINSEMI's
+own configuration mode: GowinCONFIG. The GowinCONFIG configuration
+modes that are available and supported for each device depend on the
+device model and package. The Arora Family of FPGA Products support
+bitstream encryption and security bit setting, which provides safety for user
+designs. The Arora Family FPGA products support bitstream
+decompression; users can compress bitstream to save storage memory.
+Table 3-2 lists the configuration modes that are supported by the Arora
+Family FPGA products.
+
+UG290-2.3E
+
+6(87)
+
+3 Configuration Modes
+
+3.2 Arora Family of FPGA Products
+
+Table 3-2 Configuration Modes
+Configuration Modes
+
+MODE[2:0]1
+
+Description
+
+JTAG
+
+XXX2
+
+External Host configures Arora Family of
+FPGA products via JTAG interface.
+
+MSPI
+
+000
+
+As Master, FPGA reads data from
+external Flash (or other devices) via the
+SPI interface3.
+
+SSPI
+
+001
+
+External Host configures Arora Family of
+FPGA products via SPI interface.
+
+SERIAL4
+
+101
+
+External Host configures Arora Family of
+FPGA products via DIN interface.
+
+CPU4
+
+111
+
+External Host configures Arora Family of
+FPGA products via DBUS interface.
+
+GowinCONFIG
+
+Note!
+
+
+
+
+
+[1] The unbound mode pins are grounded by default;
+[2] The JTAG configuration mode is independent of MODE value;
+[3] The SPI interfaces of the SSPI and MSPI modes are independent of each other;
+[4] The CPU configuration mode and SERIAL configuration mode share SCLK,
+WE_N and CLKHOLD_N. The data bus pins for the CPU configuration mode share
+pins with MSPI and SSPI configuration modes.
+
+Note!
+For details about configuration pins, pin reuse, and pin functions and application, please
+refer to 4 Configuration Pin.
+
+UG290-2.3E
+
+7(87)
+
+4 Configuration Pin
+
+4.1 Configuration Pin List and Reuse Options
+
+4
+
+Configuration Pin
+
+Gowin FPGA products have various configuration modes, including
+general JTAG configuration, active configuration, passive configuration,
+serial configuration and parallel configuration, etc., which can meet the
+various peripheral requirements of different users. The programming and
+configuration pins can be used as configuration pins and also can be
+reused as GPIO. Users can configure the pins as required. Users also can
+configure them according to their configuration functions to meet specific
+requirements.
+
+4.1 Configuration Pin List and Reuse Options
+4.1.1 Configuration Pin List
+Table 4-1 contains a list of all the configuration pins of Gowin FPGA
+products together with the details of the pins used in each configuration
+mode and the shared pins in chip packages.
+Table 4-1 Configuration Pin List
+GowinCONFIG
+Pin Name
+
+I/O
+
+JTAG
+
+AUTO
+BOOT
+
+SSPI
+
+MSPI
+
+DUAL
+BOOT
+
+SERIAL
+
+CPU
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+I2C
+
+RECONFIG_N
+
+I
+
+√
+
+JTAGSEL_N
+
+I
+
+√
+
+TDO
+
+O
+
+√
+
+TMS
+
+I
+
+√
+
+TCK
+
+I
+
+√
+
+TDI
+
+I
+
+√
+
+READY
+
+I/O
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+DONE
+
+I/O
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+MODE[2:0]
+
+I
+
+√
+
+√
+
+√
+
+√
+
+√
+
+√
+
+SCLK
+
+I
+
+√
+
+√
+
+UG290-2.3E
+
+√
+
+8(87)
+
+4 Configuration Pin
+
+4.1 Configuration Pin List and Reuse Options
+
+GowinCONFIG
+Pin Name
+
+I/O
+
+JTAG
+
+AUTO
+BOOT
+
+I2C
+
+SSPI
+
+MSPI
+
+√
+
+DUAL
+BOOT
+
+SERIAL
+
+CPU
+
+√
+
+√
+
+√
+
+√
+
+CLKHOLD_N/DIN
+
+I
+
+WE_N/DOUT
+
+O
+
+MI /D7
+
+I/O
+
+√
+
+√
+
+MO /D6
+
+I/O
+
+√
+
+√
+
+MCS_N /D5
+
+I/O
+
+√
+
+√
+
+MCLK /D4
+
+I/O
+
+√
+
+√
+
+FASTRD_N /D3
+
+I/O
+
+√
+
+√
+
+SI /D2
+
+I/O
+
+√
+
+√
+
+SO /D1
+
+I/O
+
+√
+
+√
+
+SSPI_CS_N/D0
+
+I/O
+
+√
+
+√
+
+SCL
+
+I
+
+√
+
+SDA
+
+I/O
+
+√
+
+Note!
+
+
+
+For the configuration modes supported by different devices, please refer to
+3Configuration Modes;
+Please refer to 5Configuration Mode Introduction for the definition of each pin in
+different configuration modes.
+
+4.1.2 Configuration Pin Multiplexing
+To maximize the utilization of I/O, Gowin FPGA products support
+setting the configuration pins as GPIO pins. Before any configuration
+operation is performed on all series of Gowin FPGA products after power
+up, all related configuration pins are used as configuration pins by default.
+After successful configuration, the device enters into user mode and
+reassigns the pin functions according to the multiplex options selected by
+the user.
+Note!
+When setting the pin multiplexing option, ensure the external initial connection state of the
+pins does not affect the device configuration. Isolate the connections that affect the
+configuration first, and then wait to modify them in user mode.
+
+The reuse options for the configuration pins are detailed in Table 4-2.
+
+UG290-2.3E
+
+9(87)
+
+4 Configuration Pin
+
+4.1 Configuration Pin List and Reuse Options
+
+Table 4-2 Pin Reuse Options
+Name
+
+Options
+
+Default Status
+
+Description
+TMS, TCK, TDI, and TDO are used as
+dedicated configuration pins. JTAGSEL_N is
+used as GPIO.
+JTAGSEL_N pins are used as dedicated
+configuration pins:
+ JTAGSEL_N=0, TMS, TCK, TDI, and
+TDO are used as configuration pins:
+ JTAGSEL_N = 1, TMS, TCK, TDI, and
+TDO are used as GPIO after
+configuration.
+SCL and SDA pins are used as dedicated
+configuration pins.
+SCL and SDA pins are used as GPIO after
+configuration.
+SCLK, CLKHOLD_N, SSPI_CS_N, SI and
+SO are used as dedicated configuration
+pins.
+SCLK, CLKHOLD_N, SSPI_CS_N, SI and
+SO are used as GPIO after configuration.
+FASTRD_N, MCLK, MCS_N, MO and MI
+are used as dedicated configuration pins.
+FASTRD_N, MCLK, MCS_N, MO and MI
+are used as GPIO after configuration.
+Dedicated configuration pins.
+
+Set as GPIO
+
+Used as GPIO after configuration.
+
+Default Status
+
+Dedicated configuration pins.
+
+Set as GPIO
+
+Used as GPIO after configuration.
+
+Default Status
+
+Dedicated configuration pins.
+
+Set as GPIO
+
+Used as GPIO after configuration.
+
+Default Status
+
+JTAG PORT
+Set as GPIO
+
+Default Status
+I2C PORT
+Set as GPIO
+Default Status
+SSPI PORT
+Set as GPIO
+Default Status
+MSPI PORT
+Set as GPIO
+RECONFIG_N
+READY
+DONE
+Note!
+
+
+
+
+[1] For the devices with JTAGSEL_N unbound, when debugging JTAG pin reuse, it's
+suggested to set MODE value to non-auto configuration mode (being neither
+auto-boot, dual boot, nor MSPI) before power up to avoid the other bit stream data
+affecting configuration. Device turns into user MODE, and JTAG pin changes into
+GPIO after power up and manually configuring JTAG. After the device is power up,
+®
+the device enters User Mode, and the JTAG pin is used as GPIO. For the LittleBee
+Family of FPGA products, when MODE[2: 0]=001, the JTAGSEL_N pin and the four
+JTAG Configuration pins (TCK, TMS, TDI, TDO) can be set as GPIOs simultaneously,
+but the JTAG pin cannot be recovered as a configuration pin by JTAGSEL_N. It can
+be recovered when the device reenters the edit mode.
+[2] The pins of SERIAL and CPU modes are shared with other configuration modes,
+so they cannot be set as GPIOs separately. However, the pins can be set as GPIOs
+in non-shared configuration modes.
+
+Configure Dual-purpose Pin
+The steps are as follows:
+1. Open the project in Gowin software;
+2. Select “Project > Configuration > Dual Purpose Pin” from the menu
+options, as shown in ;
+
+UG290-2.3E
+
+10(87)
+
+4 Configuration Pin
+
+4.2 Configuration Pin Function and Application
+
+3. Check the corresponding options.
+Figure 4-1 Configuring Pin Reuse
+
+4.2 Configuration Pin Function and Application
+The Pins RECONFIG_N, READY, and DONE pins are used in all
+configuration modes. Other pins can be set as dedicated pins or GPIO
+(Gowin Programmable IO) according to their specific application.
+Table 4-3 Pin Function
+
+Pin Name
+
+RECONFIG_N
+
+READY
+
+UG290-2.3E
+
+Functional Description
+As a configuration pin, RECONFIG_N is an input pin that has an
+internal weak pull-up. Active low is used as the reset function for the
+FPGA programming configuration. FPGA can't be configured if
+RECONFIG_N is set to low. Keep high-level during FPGA
+powering up until the powering up is stable for 1ms.
+As a configuration pin, a low level signal with pulse width no less
+than 25ns is required for GowinCONFIG to reload bitstream data
+according to the MODE setting value. You can also write logic to
+control the pin to trigger the device to reconfigure as required. As a
+GPIO pin, RECONFIG_N can only be used as the output type. To
+ensure a smooth configuration, set the initial value of RECONFIG_N
+to high.
+In-out pins. Active-high. FPGA can be configured only when the
+READY signal is pulled up. When the READY signal is pulled down,
+recover the status by powering up or triggering RECONFIG_N.
+
+11(87)
+
+4 Configuration Pin
+
+Pin Name
+
+DONE
+
+MODE
+
+JTAGSEL_N
+
+4.2 Configuration Pin Function and Application
+
+Functional Description
+As an output configuration pin, it indicates that the FPGA can be
+configured or not. If the FPGA meets the configuration condition, the
+READY signal is high. If the configuration fails, READY signal is low.
+As an input configuration pin, you can delay the configuration via its
+own logic or by pulling down the READY signal.
+As a GPIO, it can be used as an input or output type. If READY is
+used as an input GPIO, the initial value needs to be 1 before
+configuration. Otherwise, the FPGA cannot be configured.
+In-out pins. A signal which indicates FPGA is configured
+successfully, DONE is pulled up after successfully configuring.
+As an output configuration pin, it indicates the current configuration
+of FPGA: if configured successfully, the DONE signal is high and the
+device enters into working state. if the configuration fails, the DONE
+signal keeps low. As an input configuration pin, the user can delay
+the entering of user mode via its own internal logic or by reducing the
+DONE signal. When RECONFIG_N or READY signals are low,
+DONE signal also keeps low. When configuring SRAM using JTAG
+circuit, it does not need to take DONE signal into account.
+As a GPIO, it can be used as an input or output type. If DONE is
+used as an input GPIO, the initial value of DONE should be 1
+before configuring. Otherwise, the FPGA will fail to enter the
+user mode after being configured.
+GowinCONFIG modes selection pin. As the selection pin of
+GowinCONFIG modes, MODE is an input pin that has internal weak
+pull-up. The maximum bit width is 3 bits. When FPGA powers up or a
+low level pulse triggers RECONFIG_N, the device enters the
+corresponding GowinCONFIG mode in accordance with the MODE
+value. The same MODE value of the different Gowin series of FPGA
+products may have different configuration MODE. As the number of
+pins for each package is different, some MODE pins are not all
+bonded out, and the unbound MODE pins are grounded by default.
+Please refer to the corresponding PINOUT manual for further details.
+When MODE pins are used as GPIOs, they can be used as an input
+or output type.
+Note that when the MODE value changes, power-on again or
+providing one low pulse for triggering RECONFIG_N is required for it
+to take effect.
+As a configuration pin, it is an input pin with internal weak pull-up. If
+JTAG pins are set as a GPIO in the Gowin software, the JTAG pins
+can become GPIOs after the device being powered up and
+successfully configured. The JTAG pin configuration functions can
+be recovered by pulling down JTAGSEL_N. The JTAG configuration
+functions are always available if no JTAG pin reuse is set. As a
+GPIO, it can be used as an input or output type.
+Note!
+The JTAGSEL_N pin and four JTAG pins (TCK, TMS, TDI, and TDO) are
+exclusive. JTAG pins can only be used as configuration pins if JTAGSEL_N is
+set as a GPIO. JTAGSEL_N can only be used as a configuration pin if JTAG
+pins are set as GPIOs.
+
+UG290-2.3E
+
+12(87)
+
+4 Configuration Pin
+
+Pin Name
+
+TCK
+
+TMS
+
+TDI
+
+TDO
+
+SCLK
+
+CLKHOLD_N
+
+SSPI_CS_N
+
+SI
+
+SO
+
+UG290-2.3E
+
+4.2 Configuration Pin Function and Application
+
+Functional Description
+For the LittleBee® Family of FPGA products, when MODE[2: 0]=001,
+the JTAGSEL_N pin and the four JTAG pins (TCK, TMS, TDI, TDO)
+can be set as GPIOs simultaneously, but the JTAG pin cannot be
+recovered as a configuration pin by JTAGSEL_N. It can be
+recovered when the device reenters the edit mode.
+As a configuration pin, it is an input pin.
+It is a serial clock input pin in the JTAG configuration mode. As a
+GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin with internal weak pull-up.
+It is a serial input pin in JTAG configuration mode. As a GPIO, it can
+be used as an input or output type.
+As a configuration pin, it is an input pin with internal weak pull-up.
+It is a serial data input pin in JTAG configuration mode. As a GPIO, it
+can be used as an input or output type.
+As a configuration pin, it is an output pin.
+It is a serial data output pin in JTAG configuration mode. As a GPIO,
+it can be used as an input or output type.
+As a configuration pin, it is an input pin.
+It is a clock input pin in SSPI, SERIAL, and CPU configuration
+modes. As a GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin with internal weak pull-up.
+It is a clock-locking pin in SSPI and CPU configuration modes: SCLK
+is valid when the input is high, and SCLK is invalid when the input is
+low. As a GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin with internal weak pull-up. It
+is a chip selection signal in the SSPI configuration mode, active low.
+As a GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin. It is a serial data input pin in
+the SSPI configuration mode. As a GPIO, it can be used as an input
+or output type.
+As a configuration pin, it is an output pin. It is a serial data output pin
+in the SSPI configuration mode. As a GPIO, it can be used as an
+input or output type.
+
+13(87)
+
+4 Configuration Pin
+
+4.2 Configuration Pin Function and Application
+
+Pin Name
+
+Functional Description
+As a configuration pin, it is an output pin.
+The output clock pin in the MSPI configuration mode is generated
+from a crystal oscillator in FPGA. The output frequency range of the
+crystal oscillator is 2.5 MHz ~ 125 MHz, and the default output
+frequency is 2.5 MHz. The MSPI configuration mode does not
+support 125 MHz clock. Please refer to the corresponding device
+datasheet for further detailed data on the on-chip crystal oscillator.
+The MCLK frequency values can be modified through the Gowin
+software interface, as shown in Figure 4-2. Open Gowin software,
+select "Project > Configuration" from the menu options, click
+"BitStream" and select the MCLK frequency values from the
+"Download Speed" pull-down list. As a GPIO, it can be used as an
+input or output type.
+
+MCLK
+
+Figure 4-2 MCLK Frequency Setting
+
+MCS_N
+
+MI
+
+MO
+
+FASTRD_N
+
+WE_N
+D0=D7
+
+UG290-2.3E
+
+As a configuration pin, it is an output pin.
+It is a chip selection signal in MSPI configuration mode, active low.
+As a GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin.
+It is a serial data input pin in MSPI configuration mode. As a GPIO, it
+can be used as an input or output type.
+As a configuration pin, it is an output pin.
+Serial data output pin in MSPI configuration mode. As a GPIO, it can
+be used as an input or output type.
+As a configuration pin, it is an input pin.
+In the MSPI mode, FASTRD_N is used to select Flash access
+speed. High indicates regular Flash access mode(command 0x03).
+Low indicates high-speed Flash access mode;
+The high-speed flash access command of each manufacturer is
+different. Please refer to the corresponding Flash manual. As a
+GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin.
+Select the data input/output of D[7:0] in CPU mode: Read operation
+when WE_N is high; write operation when WE_N is low. As a GPIO,
+it can be used as an input or output type.
+In-out pins.
+
+14(87)
+
+4 Configuration Pin
+
+Pin Name
+
+DIN
+
+DOUT
+
+SCL
+SDA
+
+UG290-2.3E
+
+4.2 Configuration Pin Function and Application
+
+Functional Description
+Data input/output pins in CPU configuration mode, 8-bit width.
+Determine the input/output of D0 ~ D7 according to WE_N. As a
+GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin with internal weak pull-up.
+It is a serial data input pin in the SERIAL configuration mode. As a
+GPIO, it can be used as an input or output type.
+As a configuration pin, it is an output pin.
+It is a serial data output pin in the SERIAL configuration mode, which
+is only used as the input to the latter device when the FPGA is
+cascading. As a GPIO, it can be used as an input or output type.
+As a configuration pin, it is an input pin. As a GPIO, it can be used as
+an input type.
+As a configuration pin, it is an in/out pin. As a GPIO, it can be used
+as an input or output type.
+
+15(87)
+
+5 Configuration Mode Introduction
+
+5.1 Configuration Notes
+
+5
+
+Configuration Mode Introduction
+
+Gowin FPGA products include the SRAM-based high-performance
+Arora Family of FPGA products and small capacity nonvolatile device of the
+LittleBee® Family of FPGA products with embedded Flash. Any
+configuration data that is stored in the SRAM device is lost after it is
+powered down; as such, it will need to be reconfigured each time it is
+powered up. The data stored on non-volatile devices with built-in flash will
+be stored in the chip if the device is powered down, and the device can be
+automatically reconfigured after power up via the AUTOBOOT or
+DUALBOOT configuration options.
+Gowin FPGA products have abundant packages. The configuration
+modes supported by each device are related to the number of configuration
+pins bonded out: All devices support JTAG configuration, but only
+non-volatile devices support AUTO BOOT or DUAL BOOT configuration.
+The mode value for each configuration is different.
+
+5.1 Configuration Notes
+GOWINSEMI FPGA products include LittleBee® family and Arora
+family. Whether the name of the device contains R does not affect the
+configuration feature, the main difference is that SDRAM/PSRAM is
+integrated in all FPGA products that have a serial number that includes the
+letter R. Except DUALBOOT configuration features, the GW1NS series of
+FPGA products have same features as the GW1N series.
+Power Up and Configuration Flow
+When the power up voltage of VCC, VCCIO, and VCCX reaches the
+min. value, FPGA begins to start: stable voltage and RECONFIG_N is not
+pulled down > The internal circuit of FPGA pulls down READY and DONE
+pins > FPGA initialization > Pulling up READY and sampling MODE value >
+Reading and checking the configuration data according to the configuration
+mode > FPGA waking up > DONE pulling up > Entering user mode.
+Power supply voltage needs to be stable in the process of FPGA
+start-up. RECONFIG_N needs to keep high after being powered up until
+the voltage is stable for 1ms and also in the process of FPGA initialization.
+
+UG290-2.3E
+
+16(87)
+
+5 Configuration Mode Introduction
+
+5.1 Configuration Notes
+
+RECONFIG_N can be left floating or externally pulled up. All GPIOs output
+high impedance state before FPGA is waken up.
+GOWINSEMI FPGA products write bitstream data to SRAM, on-chip
+Flash, or off-chip Flash according to the data storage and the instructions.
+Only the LittleBee® Family of FPGA products support operations on on-chip
+Flash. All products support operations on SRAM and external Flash.
+SRAM Operation
+The SRAM operations include read device ID CODE and USER
+CODE, read device status register information and SRAM configuration.
+The device ID needs to be verified before configuration. Only the device
+with successful ID verification can be configured. The USER CODE is the
+identification number for users to distinguish between the devices that
+share the same ID CODE. The state register of the device records the
+status information before and after FPGA configuration, and you can use
+this information to analyze the state of the device accordingly. Please refer
+to Table 5-10 for the meaning of the status register. During SRAM
+configuration, only the bitstream data with no security bit setting supports
+validation. Data with security bit cannot be readback or verified.
+On-chip/Off-chip Flash Operation
+The built-in flash operations include erasing, programming and
+verification. The built-in flash can only be programmed via the JTAG
+interface, and the clock rate is no less than 1MHz. Please refer to Table 5-7
+for the clock rate.
+Note!
+During configuring SRAM devices via built-in Flash (AUTOBOOT configuration and
+DUALBOOT configuration) and programming built-in Flash, the FPGA needs to remain
+powered up, and the RECONFIG_N cannot be triggered at low level; otherwise, it may
+cause irreparable damages to the built-in Flash.
+
+It is required to clear the SRAM content before programming the
+embedded Flash or external Flash of the A version of LittleBee ® family
+devices. The B version of LittleBee® family devices supports the feature of
+transparent transmission. That is to say, the B version device can program
+the embedded Flash or external Flash via the JTAG interface without
+affecting the current working state. During programming, the B version
+device works according to the previous configuration. After programming,
+RECONFIG_N is triggered at low pulse to complete the online upgrade.
+This feature applies to the applications requiring long online time and
+irregular upgrades.
+Dual-purpose Pin Configuration
+In different configuration modes, users need to ensure that FPGA
+works in the selected configuration mode according to the pin functions. If
+user pins is insufficient, these pins can be configured and used as GPIOs,
+but pins associated with data transmission need to be kept. MODE [2:0] is
+used to select the GowinCONFIG programming configuration MODE.
+MODE can be fixed through pull-up or pull-down resister. It is
+recommended to use 4.7 K pull-up resister and1 K pull-down resistor.
+UG290-2.3E
+
+17(87)
+
+5 Configuration Mode Introduction
+
+5.1 Configuration Notes
+
+Note!
+The RECONFIG_N, READY, and DONE pins are associated with each configuration
+mode. Whether they are set as GPIO or not, users should ensure that their initial value or
+pin connection state meets programming and configuration conditions before completing
+the configuration process.
+
+Recommended Pin Connection
+When users are designing a circuit schematic diagram, the
+recommended connection is as shown in Figure 5-1.
+Figure 5-1 Recommended Pin Connection
+FPGA
+DC3.3V
+
+4.7K
+
+MODE[0]
+
+1K
+
+MODE[1]
+
+1K
+
+MODE[2]
+
+1K
+
+RECONFIG_N
+
+KEY
+
+READY
+DC3.3V
+
+DONE
+
+4.7K
+
+4.7K
+LED
+
+DC3.3V
+
+LED
+
+Note!
+
+
+
+
+Add the dial switch to change the MODE value; Some MODE pins of devices are not
+all bonded out, and the unbonded MODE pins are grounded by default;
+The values of READY and DONE signals have no meaningful reference in JTAG
+configuration.
+The unbonded RECONFIG_N, READY, and DONE pins have been internally
+processed, with no influence on the configuration function.
+
+Timing for Power-on Again and Triggering RECONFIG_N at Low Pulse
+Figure 5-2 and Figure 5-3 show the timing for power-on again or
+triggering RECONFIG_N at low pulse.
+Figure 5-2 Power Recycle Timing
+
+UG290-2.3E
+
+18(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-3 Trigger Timing
+
+Timing parameters of the LittleBee® Family of FPGA Products is as
+shown in Table 5-1 .
+Table 5-1 Timing Parameters for Cycling Power and RECONFIG_N Trigger
+Name
+Tportready1
+Trecfglw
+Trecfgtrdyn
+Treadylw
+Trecfgtdonel
+
+Description
+Time from application of VCC, VCCX and VCCO to the
+rising edge of READY
+RECONFIG_N low pulse width
+Time from RECONFIG_N falling edge to READY
+low
+READY low pulse width
+Time from RECONFIG_N falling edge to READY
+low
+
+Min.
+
+Max.
+
+50μs
+
+200μs
+
+25ns
+
+-
+
+-
+
+70ns
+
+TBD
+
+-
+
+-
+
+80ns
+
+Note!
+In the case of MODE0=0, the device power-up waiting time is 200 μs; If MODE0=1, the
+device power-up waiting time is 50 μs.
+
+Timing parameters of the Arora Family of FPGA Products are as
+shown in Table 5-2.
+Table 5-2 Timing Parameters for Power-on again and RECONFIG_N Triggering
+(Arora Family)
+Name
+Tportready
+Trecfglw
+Trecfgtrdyn
+Treadylw
+Trecfgtdonel
+
+Description
+Time from application of VCC, VCCX and VCCO to the
+rising edge of READY
+RECONFIG_N low pulse width
+Time from RECONFIG_N falling edge to READY
+low
+READY low pulse width
+Time from RECONFIG_N falling edge to READY
+low
+
+Min.
+
+Max.
+
+-
+
+23ms
+
+25ns
+
+-
+
+-
+
+70ns
+
+TBD
+
+-
+
+-
+
+80ns
+
+5.2 JTAG Configuration
+The JTAG configuration mode of Gowin FPGA products conforms to
+the IEEE1532 standard and the IEEE1149.1 boundary scan standard.
+The JTAG configuration mode writes bitstream data to the SRAM of
+Gowin FPGA products. All configuration data is lost after the device is
+powered down. All Gowin FPGA products support the JTAG configuration
+
+UG290-2.3E
+
+19(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+mode.
+
+5.2.1 JTAG Configuration Mode Pins
+The relevant pins for the JTAG configuration mode are shown in Table
+5-3.
+Table 5-3 Pin Description in JTAG Configuration Mode
+Pin Name
+JTAGSEL_N1
+TCK 2
+TMS2
+TDI
+TDO
+
+I/O
+I, internal weak
+pull-up
+I
+I, internal weak
+pull-up
+I, internal weak
+pull-up
+O
+
+Description
+Revert JTAG pin from GPIO to configuration
+pin. Low active
+JTAG serial clock input
+JTAG serial mode input
+JTAG serial data input
+JTAG serial data output
+
+Note!
+
+
+
+
+UG290-2.3E
+
+[1] The JTAGSEL_N works only when the JTAG pin is set as a GPIO and the device
+®
+starts to work. For the LittleBee Family of FPGA products, when MODE[2：0]= 001,
+the JTAGSEL_N pin and the four JTAG pins (TCK, TMS, TDI, TDO) can be set as
+GPIOs simultaneously, but the JTAG pin cannot be recovered as a configuration pin
+by JTAGSEL_N. It can be recovered when the device reenters the editing mode.
+[2] TCK needs to connect 4.7 K pull down resister on the PCB.
+
+20(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+5.2.2 Connection Diagram for the JTAG Configuration Mode
+The connection diagram in the JTAG configuration mode is shown in
+Figure 5-4.
+Figure 5-4 Connection Diagram for JTAG Configuration Mode
+FPGA
+
+JTAGSEL_N
+TDI
+
+JTAG PORT
+
+TCK
+TMS
+TDO
+
+4.7K
+
+Note!
+
+
+
+
+If JTAGSEL_N is not bonded out, when debugging the JTAG pin reuse, it is
+suggested to set the MODE value to non-auto configuration mode (AUTOBOOT,
+DUALBOOT or MSPI) before powering up the device to avoid the other bitstream
+data affecting configuration. After power up and JTAG is configured manually, the
+device enters User MODE, and JTAG pin will be used as a GPIO.
+The clock frequency for JTAG configuration mode is no higher than 40MHz.
+
+In addition to using JTAG to configure SRAM, the built-in Flash of
+Gowin non-volatile FPGA devices (LittleBee® Family) and the external SPI
+Flash of all other FPGA series programming can also be configured
+through the JTAG pin. The connection for programming the built-in Flash of
+the non-volatile devices is the same as that of the JTAG mode. Please refer
+to Figure 5-41 and 8 Boundary Scan for external SPI Flash programming.
+In addition, Gowin FPGA products support JTAG daisy chain operation,
+which connects the FPGA TDO pin to the next FPGA TDI pin. Gowin
+programming software will identify the connected FPGA devices
+automatically and configure them in turn. The connection diagram for the
+daisy chain configuration is shown in Figure 5-5.
+
+UG290-2.3E
+
+21(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-5 Connection Diagram of JTAG Daisy-Chain Configuration Mode
+
+TCK
+
+TMS
+
+TMS
+
+TDI
+
+TDI
+
+TDO
+
+FPGA
+
+TCK
+TMS
+TDI
+TDO
+
+TCK
+
+READY
+RECONFIG_N
+DONE
+
+TCK
+
+FPGA
+
+TMS
+TDI
+TDO
+
+READY
+RECONFIG_N
+DONE
+
+FPGA
+
+READY
+RECONFIG_N
+DONE
+
+JTAG PORT
+
+TDO
+
+Note!
+DONE, RECONFIG_N, and READY can be connected or not as appropriate.
+
+5.2.3 JTAG Configuration Timing
+See Figure 5-6 for the timing of JTAG mode.
+Figure 5-6 JTAG Configuration timing
+
+See Table 5-4 for the description of timing parameters.
+Table 5-4 JTAG Configuration Timing Parameters
+
+UG290-2.3E
+
+Name
+
+Description
+
+Min.
+
+Max.
+
+Ttckftco
+
+Time from TCK falling edge to output
+
+-
+
+10ns
+
+Ttckftcx
+
+Time from SCLK falling edge to high impedance
+
+-
+
+10ns
+
+Ttckp
+
+TCK clock period
+
+40ns
+
+-
+
+Ttckh
+
+TCK clock high time
+
+20ns
+
+-
+
+Ttckl
+
+TCK clock low time
+
+20ns
+
+-
+
+Tjps
+
+JTAG PORT setup time
+
+10ns
+
+-
+
+Tjph
+
+JTAG PORT hold time
+
+8ns
+
+-
+
+22(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+5.2.4 JTAG Configuration Process
+TAP State Machine
+The state machine for the test access port is designed to select an
+instruction register or a data register to connect it between TDI and TDO. In
+general, the instruction register is used to select the data register to be
+scanned. In the state machine diagram, the number on the side of the
+arrow indicates the logic state of the TMS when the TCK goes high, as
+shown in Figure 5-7.
+Figure 5-7 TAP State Machine
+
+TAP Reset
+After TMS keeps high (logic "1") and at least 5 strobes are input
+(higher and then low) at the TCK terminal, the TAP logic is reset, the TAP
+state machine in other states is converted into the state of test logic reset,
+and the JTAG port and the test logic are reset.
+Note!
+The CPU and peripherals are not reset in this state.
+Note!
+
+
+
+
+
+
+The data on the TDO is valid from the falling edge of TCK in the Shift_DR or Shift_IR
+state;
+The data is not shifted in the Shift_DR or Shift_IR state;
+The data is shifted when leaving the Shift_DR or Shift_IR;
+The first to be shifted is the least significant bit (LSB) of the data;
+Once reset, all instructions will be reset or disabled.
+
+Instruction Register and Data register
+In addition to the test logic reset, the state machine can also control
+two basic operations:
+
+UG290-2.3E
+
+23(87)
+
+5 Configuration Mode Introduction
+
+
+
+
+5.2 JTAG Configuration
+
+Instruction register (IR) scan;
+Data Register (DR) scan.
+
+During the IR scanning operation, in Shift_IR state, the data or
+instructions are sent to the IR in the LSB way. The lower data bits are sent
+first. The instructions will be all sent when the sate machine returns to
+Run-Test-Idle, as shown in Figure 5-8
+During the data register scanning operation, the data or instructions
+are sent to the DR in the Shift_DR state, as shown in Figure 5-9. The data
+is sent in LSB way or MSB way depending on specific operations.
+Figure 5-8 Instruction Register Access Timing
+
+Figure 5-9 Data Register Access Timing
+
+Note!
+
+
+
+UG290-2.3E
+
+The total length of the instruction register is 8 bits in the GW1N(R) and GW2A(R)
+series of the FPGA;
+The length of the data register can vary depending on the selected register.
+
+24(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Read ID CODE Instance
+ID Code, i.e. JEDEC ID Code, is a basic identification of FPGA
+products.
+The length of the Gowin FPGA ID Code is 32 bits. The ID Codes of the
+FPGA are listed in the following table.
+Table 5-5 Gowin FPGA IDCODE
+
+Gowin FPGA Device Family IDCODE
+Device Part
+Device Family
+
+Manufacturer ID
+Bits 11-0
+
+Bits 31-12
+
+IDCODE
+
+h81B
+
+GW1N-1
+
+h09002
+
+h0900281B
+
+GW1N-1S
+
+h09003
+
+h0900381B
+
+GW1NZ-1
+
+h01006
+
+h0100681B
+
+GW1NS-2
+
+h03000
+
+h0300081B
+
+GW1NS(R)-2C
+
+h03001
+
+h0300181B
+
+GW1NSE-2C
+
+h03001
+
+h0300181B
+
+GW1N(R)-4
+
+h01001
+
+h0100381B
+
+GW1N(R)-4B
+
+h11003
+
+h1100381B
+
+GW1N(R)-4C
+
+h11003
+
+h0100181B
+
+GW1NS(ER)-4C
+
+h01009
+
+h0100981B
+
+GW1N(R)-9
+
+h11005
+
+h1100581B
+
+GW1N(R)-9C
+
+h11005
+
+h1100481B
+
+GW2A(R)-18/18C
+
+h00000
+
+h0000081B
+
+GW2A-55/55C
+
+h00002
+
+h81B
+
+h0000281B
+
+The instruction for reading FPGA is 0x11. Take the GW1N-4B ID Code
+as an example to illustrate the working mode of JTAG, please refer to the
+following steps:
+1. TAP reset: TMS is set to high level and at least 5 clock cycles are
+continuously transmitted;
+2. Move the state machine from Test-Logic-Reset to Run-Test-Idle;
+3. Move the state machine to Shift-IR. Send Read ID instruction (0x11)
+beginning with LSB. When MSB (the last bit) is being sent, move state
+machine to Exit1-IR at the same time, i.e., TMS should be high level
+before sending MSB. Table 5-6 shows the change of TDI and TMS
+value during sending 0x11 in 8-clock cycle. The timing is as shown in
+Figure 5-11.
+Table 5-6 Change of TDI and TMS Value in The Process of Sending Instructions
+
+TCK 1
+
+TCK 2
+
+TCK 3
+
+TCK 4
+
+TCK 5
+
+TCK 6
+
+TCK 7
+
+TCK 8
+
+TDI value
+(0x11)
+
+1
+
+0
+
+0
+
+0
+
+1
+
+0
+
+0
+
+0
+
+TMS
+
+0
+
+0
+
+0
+
+0
+
+0
+
+0
+
+0
+
+1
+
+UG290-2.3E
+
+25(87)
+
+5 Configuration Mode Introduction
+
+TCK 1
+
+5.2 JTAG Configuration
+
+TCK 2
+
+TCK 3
+
+TCK 4
+
+TCK 5
+
+TCK 6
+
+TCK 7
+
+TCK 8
+
+value
+
+4. Move the state machine, back to Run-Test-Idle after going from
+Exit1-IR to Update-IR, and then run the state machine at least 3 clock
+cycles in Run-Test-Idle.
+5. Move the state machine to Shift-DR, send 32 clock cycles, and set
+TMS to high level before the 32nd clock is sent. When the 32 clock
+cycles are completed, jump from Shift-DR to Exit1-DR. During this
+period, sending 32 clocks can read 32 bits data, that is, 0x0100381B,
+as shown in Figure 5-12;
+6. Move the state machine back to Run-Test-Idle;
+Figure 5-10 Read Machine Flow Chart in ID Code State
+Start
+Move TAP to Shift-DR
+Move TAP to Shift-IR
+
+Transfer
+Read ID Code(0x11)
+instruction (LSB)
+&
+Move TAP to Exit1-IR
+
+Move TAP to UpdateIR
+
+Transfer 32 clocks to
+get ID Code
+&
+Move TAP to Exit1DR
+
+Move TAP to UpdateDR
+
+Move TAP to RunTest-Idle
+
+Move TAP to RunTest-Idle
+End
+
+Figure 5-11 The Access Timing of Read ID Code Instruction- 0x11
+
+UG290-2.3E
+
+26(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-12 Read ID Code Data Register Access Timing
+
+SRAM Configuration Process
+The FPGA SRAM is configured using an external Host to enable the
+FPGA functions. SRAM is configured via JTAG to avoid the influence of
+Configuration Mode Pins.
+Generate the FS file using Gowin software. Configure SRAM via JTAG.
+The process of SRAM configuration using the external Host is as follows,
+as shown in Figure 5-13.
+1. Establish a JTAG link and reset TAP;
+2. Read the device ID CODE and check if it matches.
+3. Erase the SRAM if it has been configured. Please refer to “SRAM
+Erasure Process”.
+4. Send the "0x15" instruction of ConfigEnable;
+5. Send the "0x12" instruction of Address Initialize;
+6. Send the "0x17" instruction of Transfer Configuration Data.
+7. Move the state machine to Shift-DR (Data Register). Send
+Configuration Data from the MSB bit by bit till all the bitstream file
+content is sent.
+8. Send the "0x3A" instruction of ConfigDisabled;
+7. Send the "0x02” instruction of Noop to end the configuration process.
+8. Please refer to Process of Reading SRAM (The process of reading
+SRAM) if reading back Configuration Data is required for verification.
+
+UG290-2.3E
+
+27(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-13 SRAM Configuration Flow
+Check
+ID Code
+
+N
+
+Y
+
+See Read Flow
+
+N
+
+End
+
+Y
+
+SRAM Erase (Option)
+
+Transfer
+Config Enable Instruction
+(0x15)
+
+Transfer
+Address Init Instruction
+(0x12)
+
+Transfer Write Instruction
+(0x17)
+
+Transfer Bitstream(MSB)
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+Transfer
+NOOP Instruction
+(0x02)
+
+Verify
+
+Y
+
+See Read Flow
+
+N
+
+End
+
+Process of Reading SRAM
+Warning: SRAM data is not allowed to be read back by default.
+Read the SRAM data from the SRAM area of the FPGA. First ensure
+that the security bit is not configured when the data are written to the
+SRAM. The security bit is used to protect the runtime data and ensure the
+data security. After the safety bit is set, the data received from the SRAM
+are 1 (high level).
+UG290-2.3E
+
+28(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+During loading, FPGA performs CRC check on the written data to
+ensure that the data is written correctly, and whether CRC reports an error
+can be used as a check mechanism to configure SRAM.
+Table 5-7 Count of Address and Length of One Address
+Device
+
+Length of One Address (bits/address)
+
+Count of Address
+
+GW1N-1/GW1N-1S/
+GW1NZ-1
+
+1216
+
+274
+
+GW1N-2/GW1N(R)-4B/
+GW1NS(E/R)-2(C)
+
+2296
+
+494
+
+GW1N(R)-6/GW1N(R)-9
+
+2836
+
+712
+
+GW2A(R)-18
+
+3376
+
+1342
+
+GW2A(R)-55(ES)
+
+5536
+
+2038
+
+The reading process is described in detail below, as shown in Figure
+5-14.
+1. Send the "0x15" instruction of ConfigEnable;
+2. Send the "0x12" instruction of Address Initialize;
+3. Send the "0x 03" instruction of SRAM Read;
+4. Move the state machine to Shift-DR (data register) and
+send as many clocks as the value of the address length, see Table 5-7.
+When the last clock is sent, pull up TMS at the same time. The state
+machine jumps to Exit1-DR, and TDO reads data with corresponding
+length. The state machine will return to Run-Test-Idle state finally.
+5. Repeat the step 4, the address will be automatically accumulated when
+the data of an address are read each time;
+6. Send the "0x3A" instruction of ConfigDisabled;
+7. Send the "0x02” instruction of Noop to end the reading process.
+
+UG290-2.3E
+
+29(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-14 Process of reading SRAM
+Start
+
+Transfer
+Config Enable Instruction
+(0x15)
+
+Transfer Initialize Address
+Instruction (0x12)
+
+Transfer
+Read Instruction
+(0x03)
+
+Next address is valid
+Y
+Read data of one address
+N
+
+Compute the
+checksum(16bit)
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+End
+
+SRAM Erasure Process
+When reconfiguring SRAM, the existing SRAM needs to be erased.
+The flow is as follows:
+1. Send the "0x15" instruction of ConfigEnable;
+2. Send the "0x05" instruction of SRAM Erase;
+3. Send the "0x02 " instruction of Noop;
+4. Delay or Run Test 2~10ms;
+5. Send the "0x09" instruction of SRAM Erase Done;
+6. Send the "0x3A" instruction of ConfigDisabled;
+
+UG290-2.3E
+
+30(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+7. Send the "0x02” instruction of Noop to end the Erasure process.
+Note!
+You need to wait enough time for the device to finish erasing after the instructions of
+EraseSram(0x05) and Noop(0x02) are sent.
+
+The reference time for GW1N(*)-1 is 1ms;
+
+The reference time for GW1N(*)-4 is 2ms;
+
+The reference time for GW1N(*)-9 is 4ms;
+
+The reference time for GW2A(*)-18 is 6ms;
+
+The reference time for GW2A(*)-55 is 10ms.
+
+Erase Internal Flash
+For the embedded Flash memory of GW1N series, the embedded
+Flash needs to be erased before each programming task. For data security,
+the embedded Flash must be erased entirely.
+The requirements for JTAG programming frequency are different
+according to the different processes of the GW1N series of the embedded
+Flash. Please refer to Table 5-8.
+Table 5-8 TCK Frequency Requirements for JTAG
+Device
+GW1N-1
+GW1N-1S
+GW1N(RF)-4B
+GW1N(SER)-4C
+GW1N(R)-9(C)
+GW1NZ-1
+GW1NS(E)-2(C)
+
+TCK Frequency Range
+
+Process Code
+
+1.4MHz ~ 5MHz
+
+H
+
+1MHz ~ 5MHz
+
+T
+
+1MHz ~ 5MHz
+
+S
+
+FPGA erasure process of T Technology
+
+The following describes the erase flow of T Technology for GW1NZ-1
+in detail, as shown in Figure 5-15.
+1. Establish a JTAG link and reset the TAP;
+2. Read the device ID CODE and check if it matches.
+3. Erase SRAM first if it has been configured.
+4. Send the "0x15" instruction of ConfigEnable;
+5. Send the "0x75" instruction of EFlash Erase;
+6. The clock（Run-Test） is continuously generated in Run-Test-Idle for
+500μs;
+7. Move the state machine in turn: Run-Test-ldle -> Select-DR-Scan->
+Update-DR -> Capture-DR -> Shift-DR -> Transfer 32 bits-> Exit1-DR ->
+Update-DR -> Run-Test-ldle;
+8. The clock（Run-Test）is continuously generated in Run-Test-Idle for
+120ms. Please refer to Table 5-8 for the frequency requirements;
+9. Send the "0x3A" instruction of ConfigDisabled;
+10. Send the "0x02” instruction of Noop to end the erasure process.
+11. Send the "0x03” instruction of Reprogram to reconfigure the device and
+check if it erases successfully.
+
+UG290-2.3E
+
+31(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-15 The Embedded Flash Erasing process of T Technology
+Start
+
+SRAM Erase
+
+Run-Test 500 us
+
+Transfer
+Config Enable Instruction
+(0x15)
+
+Transfer
+EFlash Erase Instruction
+(0x75)
+
+Move TAP through
+Run-Test-Idle ->
+Select-DR-Scan - -> Capture-DR -> Shift-DR
+-> Exit1-DR -> Pause-DR -> Exit2-DR -> Shit-DR -> Exit1-DR
+-> Update-DR -> Run-Test-Idle
+
+Run-Test 120 ms
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+Transfer
+Read-ID-Code Instruction
+(0x11)
+
+Transfer
+Repogram Instruction
+(0x3C)
+
+Transfer
+Noop Instruction
+(0x02)
+
+End
+
+Note!
+Ignore the shading area operation during Background Programming.
+
+FPGA erasure process of H Technology
+
+FPGA erasure process of H Technology:
+1. Send the "0x15" instruction of ConfigEnable;
+2. Send the "0x75" instruction of EFlash Erase;
+3. Move the state machine from Run-Test-Idle to Shift-DR; 32 clocks are
+generated (TDI signal keeps low level). Move the state machine to
+Exit1-DR at the 32th clock, and then return to Run-Test-Idle going from
+
+UG290-2.3E
+
+32(87)
+
+5 Configuration Mode Introduction
+
+4.
+5.
+6.
+7.
+8.
+
+UG290-2.3E
+
+5.2 JTAG Configuration
+
+Update-DR;
+Repeat the steps above, 65 times in all;
+The clock（Run-Test）is continuously generated in Run-Test-Idle for
+120ms. Please refer to Table 5-8 for the frequency requirements;
+Send the "0x3A" instruction of ConfigDisabled;
+Send the "0x03" instruction of Reprogram to check if the erasing is
+successful;
+Send the "0x02” instruction of Noop to end the erasure process.
+
+33(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-16 The Embedded Flash Erasing process of S Technology
+Start
+
+Transfer
+Config Enable Instruction
+(0x15)
+
+Transfer
+SRAM Erase Instruction
+(0x05)
+
+Run-Test 1ms
+
+Transfer
+SRAM Erase Done Instruction
+(0x09)
+
+Run-Test 500 us
+
+Transfer
+EFlash Erase Instruction
+(0x75)
+
+Repeat 65 times:
+Run-Test-Idle ->
+Select-DR-Scan -> Update-DR -> Capture-DR -> Shift-DR
+-> Transfer 32 bits -> Exit1-DR
+-> Update-DR -> Run-Test-Idle
+
+Run-Test 96 ms
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+Transfer
+Noop Instruction
+(0x02)
+
+End
+
+GW1NS(E)-2(C) Erasure Process of S Technology
+
+GW1NS(E)-2(C) offers two built-in Flash. Note the different Flash
+when programming. Refer to the process below:
+1. Check if the device ID is matched;
+2. Send the "0x15" instruction of ConfigEnable;
+3. If the second Flash needs to be erased, send the "0x78” instruction of
+Flash 2nd Enable.
+
+UG290-2.3E
+
+34(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Note!
+The condition to erase the second Flash is that FPGA should be in the Wakeup state.
+(Done Final of Status Code should be 1.)
+
+4. Send the "0x75" instruction of EFlash Erase;
+5. Move the state machine to Shift-DR, and generate a clock of 110ms.
+Please refer to Table 5-8 for the frequency requirements. Return to
+Run-Test-Idle;
+6. Send the "0x3A" instruction of ConfigDisabled;
+7. Send the "0x02” instruction of Noop to end the process.
+Process of Programming Internal Flash
+The internal Flash uses 256Bytes as an X-page. Each X-page is
+divided into 64 Y-pages, and each Y-page contains 4Bytes.
+The first Y-page of the first X-page is used to identify whether the
+Flash has the capability of Autoboot or Readback, as shown in Table 5-9.
+When Readable-pattern is written to the first Y-page, the Flash data can be
+read; when the Autoboot-pattern is written to the first Y-page, the device
+automatically loads the Flash data into the SRAM in the autoboot mode;
+The Flash can only be read after the Readable-pattern is written. It cannot
+be read in any other cases. Devices with the feature of background
+programming just need to use Autoboot-pattern.
+Autoboot-pattern data must be inserted in the header of bitstream file
+in the case of no requirements of reading back data. If an X-page is less
+than 256Bytes, you can use 0xFF or 0x00 to complement it.
+The requirements for JTAG programming frequency are different
+according to the different processes of the embedded Flash in GW1N
+series. Please refer to SRAM Erasure Process> Table 5-8 TCK Frequency
+Requirements for JTAG.
+Table 5-9 Readback-pattern / Autoboot-pattern
+Device
+
+Readable-pattern(4 Bytes)
+
+GW1N-1/GW1N-1S
+
+0x07,0x07,0x30,0x40
+
+GW1N(R)-2/4
+GW1N(R)-2B/4B/9
+GW1NZ-1
+GW1NS(E)-2(C)
+
+0xF7,0xF7,0x3F,0x4F
+
+Autoboot-pattern(4 Bytes)
+
+0x47,0x57,0x31,0x4E
+
+The process of programming internal Flash is shown in :
+1. Check whether the ID Code matches;
+2. Erase the embedded Flash;
+3. Verify if the erasure is successful by reading the Status register to
+check if the device has been restored to the initial state of the die; the
+background programming devices and the GW1NS series of devices
+cannot be checked by reading the Status register;
+4. Send the "0x15" instruction of ConfigEnable;
+5. Write one X-page at a time until the programming is completed;
+6. Send the "0x3A" instruction of ConfigDisabled;
+7. Send a Reprogram instruction (0x3C) to load the Flash data into the
+SRAM;
+
+UG290-2.3E
+
+35(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+8. Read Status Code/User Code to check if the loading is successful.
+Figure 5-17 Process of Programming Internal Flash View
+
+Start
+
+Check
+ID Code
+
+Y
+
+N
+
+Y
+
+See ReadIDCode
+
+Erase Flash
+
+Verify
+
+Y
+
+Program the first X-page
+with readable-pattem
+
+N
+Transfer
+Config Enable Instruction
+(0x15)
+
+Erase Flash
+
+Program Bitstream to
+pages, one page have 64
+X-pages, one X-page
+have 4Y-pages.
+
+Transfer
+Reprogram Instruction
+(0 x 3C)
+
+N
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+Verify
+
+Y
+
+See Read EFlash
+Flow
+
+Y
+
+Same as FS file?
+
+N
+
+N
+Transfer
+Repogram Instruction
+(0x3C)
+
+Transfer
+Noop Instruction
+(0x02)
+
+End
+
+Process of Programming an X-page
+
+The process of programming an X-page is as shown in Figure 5-18.
+1.
+2.
+3.
+4.
+
+UG290-2.3E
+
+Send the "0x15" instruction of ConfigEnable;
+Send the "0x71" instruction of EF-Program;
+Enter into Shift-DR and send address data1;
+Write an X-page data.
+
+36(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+One Y-page has 256 bytes in all. Program 4 Bytes and program 64
+times for one Y-page. The Y-page data is written in LSB way. Refer to
+Figure 2-15.
+5. After one X-page is written in, GW1N-1(S) needs to perform Run-Test
+for 2400μs; GW1N(Z)-2/4/6/9 needs to perform Run-Test for 6μs. No
+extra clock is required for the other series of devices.
+6. This X-page programming ends.
+Note!
+Address data format is 32 bits altogether, and the lower 6 bits are reserved. For example,
+when the address is b’00010011(0x13), the written-in address is
+00000000000000000000010011000000. The address data is written in LSB way. Jump
+out of Shift-DR at the last bit.
+
+Figure 5-18 X-page Programming
+Start
+
+Transfer Config-Enable
+Instuction (0x15)
+
+Transfer EF-Program
+Instuction (0x71)
+
+Address index > 0
+
+Delay 16000ns in Run-TestIdle
+
+Y
+N
+
+Transfer address data (LSB)
+
+Delay 16000ns
+
+Program 1 X-Page
+
+Delay
+6μS (GW1N(Z)-2/4/6/9)
+Or
+2400μS (GW1N-1(S))
+in Run-Test-Idle
+
+End
+
+Process of Programming an Y-page
+
+Y-page programming is the smallest unit in programming process. 4
+Bytes are written each time in the LSB way, as shown in Figure 5-19.
+Different series of devices all need to perform Run-Test to wait for
+writing all Bytes, and the JTAG clock needs to meet minimum frequency
+requirements. Refer to Table 5-8.
+
+UG290-2.3E
+
+37(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+After one Y-page is written in each time, GW1N(Z)-2/4/6/9 needs to
+perform Run-Test for 13-15 μs; GW1N(S)-2(C) needs to perform Run-Test
+for 30-35 μs. No extra clock is required for the other series of devices.
+Note!
+If you want to read data from Configuration Data, high 4 Bytes will be taken. If you want to
+write data into Shift-DR, LSB will begin to write.
+
+Figure 5-19 Y-page Programming
+
+Start
+
+Move TAP to SHIFT-DR
+
+Transfer 4 Bytes (LSB)
+
+Move Tap to Exit-DR,
+Update-DR&Run-Test-Idle
+
+Run-Test 13μS(GW1N(Z)2/4/6/9)
+Or
+Run-Test 30μS(GW1NS(E)2(C))
+
+End
+
+Process of Reading internal Flash
+This chapter introduces the process of reading internal Flash briefly,
+no rate requirements for the TCK of JTAG, as shown in Figure 5-20.
+Reading the internal Flash can be regarded as the reverse process of
+programming Flash. But firstly, you should make sure that the written-in
+Readable-pattern has taken effect. For GW1N, the Reprogram(0x3C) and
+Noop(0x02) can be sent in turn after Readable-pattern is written-in to make
+the internal flash be Readable.
+Process Description:
+1. Check ID Code. (optional);
+2. Send the "0x15" instruction of ConfigEnable;
+3. Send EF-Read instruction 0x73;
+4. Send read Flash start address 0x0. The method is same as write
+UG290-2.3E
+
+38(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+X-address in 0;
+5. 64 Y-page is an X-page;
+6. After reading one X-page, need not to send address again. The
+address will recurse automatically;
+7. After reading, send the "0x3A" instruction of ConfigEnable to end the
+process.
+Figure 5-20 Process of Reading Internal Flash
+Start
+
+Check
+ID Code
+
+Y
+
+See ReadIDCode
+
+N
+Y
+N
+Transfer
+Config Enable Instruction
+(0x15)
+Transfer
+EF-Read Instruction
+(0x73)
+Transfer address(0x0) data
+(LSB)
+
+Read pages
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+End
+
+Process of Reading a Page (Y-page) Flash
+
+Reading a Y-page is similar to writing a Y-page, but there is no waiting
+time for writing in Flash. As shown in Figure 5-21.
+The lowest bit in the data is outputted first.
+
+UG290-2.3E
+
+39(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-21 Process of Reading a Y-page
+
+Start
+
+Move TAP to SHIFT-DR
+
+Transfer 4 Bytes(all 0x0),
+and get Y-page data from
+TDO, data is LSB.
+
+Move TAP to Exit1-DR，
+Update-DR & Run-Test-Idle
+
+End
+
+UG290-2.3E
+
+40(87)
+
+5Configuration Mode Introduction
+
+5.2JTAG Configuration
+
+Background Programming
+The device sometimes needs to upgrade the data file and program the
+Flash without affecting current functions. And it can maintain the I/O state
+when adding a new data stream file. The following is the flow of GW1N4
+that upgrades the internal Flash data using the Background Programming.
+Figure 5-22 GW1N-4 Background Programming Flow
+Start
+
+Flash Erase
+
+Flash Program
+NG
+
+Verify
+
+Y
+
+N
+
+Flash Readback
+
+Y
+
+Transfer JTAG Instructions
+Sample(0x01) & Extest(0x04)
+
+Toggle
+reconfig_N pin
+
+Transfer JTAG Instructions
+NOOP (0xFF)
+
+End
+
+UG290-2.3E
+
+41(89)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-23 Transfer JTAG Instruction Sample & Extest Flow Chart
+Start
+
+Run-Test/IDLE
+
+Shift-IR
+(Transfer Sample Instruction
+0x01)
+
+Update-IR
+①
+Select-DR-Scan
+
+Capture-DR
+
+Exit1-DR
+
+Update-DR
+
+Select-DR-Scan
+
+Shift-IR
+(Transfer Extest Instruction
+0x04)
+
+Update-IR
+
+Run-TEST/IDLE
+
+End
+
+Note!
+○
+1 Jump directly from Update-IR to Select-DR-Scan.
+
+ExFlash Programming
+Gowin FPGA can load bitstream files from external Flash and program
+external Flash through JTAG directly.
+
+UG290-2.3E
+
+42(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-24 Connection Diagram of JTAG Programming External Flash
+FPGA
+
+Flash
+
+JTAG PORT
+
+TDI
+
+MCLK
+
+CLK
+
+TCK
+
+MCS_N
+
+CS_N
+
+TMS
+
+MI
+
+DOUT
+
+TDO
+
+MO
+
+DIN
+
+4.7K
+
+Note!
+The figure above shows the minimum system diagram of programming external Flash via
+JTAG.
+
+Program External Flash via JTAG-SPI
+
+In this mode, the external Flash can be programed via JTAG.
+The principle of this mode is to convert JTAG protocol to SPI protocol
+and then program external Flash. Users program SPI Flash by simulating
+Master SPI timing through JTAG.
+Figure 5-25 Process View of Programming SPI Flash SPI
+Start
+
+Check
+ID Code
+
+Y
+
+See RaadIDCode
+
+N
+Transfer
+Program_SPI Instruction
+(0x16)
+
+Program (or read) SPI
+through JTAG
+
+End
+
+UG290-2.3E
+
+43(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Figure 5-26 Timing Diagram of Sending 0x06 via GW2A series JTAG Simulating
+SPI
+
+Figure 5-27 Timing Diagram of Sending 0x06 via GW1N series JTAG Simulating
+SPI
+
+Program SPI Flash in JTAG Boundary Scan Mode
+
+The principle of this mode is changing the state of the pins connected
+to SPI by using Boundary Scan method to implement SSPI timing, and
+then to program the internal Flash.
+The length of the Boundary Scan Chain used in this mode is 8 bits.
+Every two bits combination corresponds to the pin state, as shown in Table
+5-10. One SCLK drive is completed every two times of sending Boundary
+Scan Chain.
+Table 5-10 Pin State
+
+UG290-2.3E
+
+Pins Name of SPI Flash
+
+SCLK
+
+Bscan Chain[7:0]
+
+7
+
+(ctrl & data)
+
+0
+
+CS
+6
+
+5
+0
+
+DI
+4
+
+3
+0
+
+DO
+2
+
+1
+
+0
+
+1
+
+44(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Note!
+
+
+
+ctrl:0 means output, 1 means input;
+data:0 means low, 1 means high.
+
+Figure 5-28 Process of Use Boundary Scan Mode To Program SPI Flash
+Start
+
+Check
+ID Code
+
+Y
+
+See RaadIDCode
+
+N
+Transfer
+Config Enable Instruction
+(0x15)
+
+Transfer
+BSCAN_2_SPI Instruction
+(0x3D)
+
+Program (or read) SPI
+through JTAG
+
+Transfer
+Config Disable Instruction
+(0x3A)
+
+End
+
+UG290-2.3E
+
+45(87)
+
+5 Configuration Mode Introduction
+
+5.2 JTAG Configuration
+
+Read Status Register 0x41
+Status Register is of great help in device debugging and observing
+device Status. Reading Status Register can preliminarily judge the Status
+of devices, such as whether wakeup is successful or not, whether there is a
+loading error, etc.
+The Status Register is 32 bits, the read instruction is 0x41 and the
+timing is the same as that of Read ID Code.
+The meaning of the Status Register is shown in Table 5-11.
+Table 5-11 Status Register Definition
+Device
+Status
+Register[31:0]
+
+GW1N(R)-1/2/4
+
+0
+
+CRC Error
+
+1
+
+Bad Command Error
+
+2
+
+ID Verify Failed Error
+
+3
+
+Timeout Error
+
+4
+
+0
+
+5
+
+-
+
+6
+
+-
+
+7
+
+-
+
+8
+
+-
+
+9
+
+0
+
+10
+
+-
+
+11
+
+-
+
+12
+
+Gowin VLD(1)
+
+13
+
+Done Final
+
+14
+
+Security Final
+
+15
+
+Ready(1)
+
+16
+
+GW1NS-2
+GW1NS(R)-2C
+
+GW1N(R)-6/9
+GW1NZ-1
+
+GW2A-18/55
+
+0
+
+Ready(0)
+
+Ready(1)
+
+POR(1)
+
+Encrypted
+format
+Encrypted key is
+right
+
+17
+
+0
+
+-
+
+18
+
+0
+
+-
+
+19-31
+
+0
+
+-
+
+0
+0
+
+0
+
+* Gowin VLD is associated with the embedded Flash.
+
+UG290-2.3E
+
+46(87)
+
+5.3 AUTO BOOT Configuration (Supported by LittleBee®
+Family Only)
+
+5 Configuration Mode Introduction
+
+Read Code 0x13
+The user code is 32 bits, the read instruction is 0x13 and the timing is
+the same as that of Read ID Code.
+The user code adopts the checksum value in the FS file by default. It
+can be redefined using Gowin Designer.
+Reload 0x3C
+This instruction is used to read the bitstream files from Flash and write
+to SRAM.
+Send the instructions of Reprogram (0x3C) and Noop (0x02) to reload
+the device via JTAG. You can also reload the device by triggering the
+Reconfig_N pin.
+Connection Diagram of Daisy-Chain
+Figure 5-29 Connection Diagram of Daisy-Chain
+
+TCK
+
+TMS
+
+TMS
+
+TDO
+
+TDI
+
+TDI
+
+FPGA
+
+TCK
+TMS
+TDI
+TDO
+
+TCK
+
+READY
+RECONFIG_N
+DONE
+
+TCK
+
+FPGA
+
+TMS
+TDI
+TDO
+
+READY
+RECONFIG_N
+DONE
+
+FPGA
+
+READY
+RECONFIG_N
+DONE
+
+JTAG PORT
+
+TDO
+
+Routine File
+For the routine file, please contact GOWINSEMI technical support or
+the local office.
+
+5.3 AUTO BOOT Configuration (Supported by LittleBee®
+Family Only)
+The AUTO BOOT mode is a configuration mode for momentary
+connection feature of non-volatile LittleBee® family of FPGA Products. The
+Arora Family of FPGA products do not support AUTO BOOT mode. In
+AUTO BOOT mode, FPGA reads bitstream data from the built-in Flash
+automatically after it is powered on, with no connection to an external
+configuration port.
+In the AUTO BOOT mode, the bitstream data needs to be written to
+
+UG290-2.3E
+
+47(87)
+
+5 Configuration Mode Introduction
+
+5.3 AUTO BOOT Configuration (Supported by LittleBee®
+Family Only)
+
+the built-in Flash via the JTAG port first (refer to Figure 5-4 Connection
+Diagram for JTAG Configuration Mode), and then set the MODE value to
+"000", the chip will automatically read the bitstream data to complete
+configuration when powered up again or RECONFIG_N triggered at a
+low-level pulse. When the MODE value is set to "000", the FPGA will
+automatically configure the SRAM to complete AUTO BOOT after the
+built-in Flash is programmed using Gowin programmer. The momentary
+connection feature of the built-in Flash saves download time and improves
+productivity.
+GW1N(R) - 9 and GW1NS series support two retries of AUTO BOOT
+configuration, i.e. the devices can be automatically reconfigured twice if the
+first configuration fails after power up. The other devices of LittleBee ® only
+support one-time AUTO BOOT configuration. The factors that can lead to a
+failed configuration include false ID validation, false CRC check, and false
+instruction.
+Note!
+The embedded Flash can only store one bitsteam file. The retry address
+configuration could not be changed
+
+UG290-2.3E
+
+48(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+5.4 SSPI
+In SSPI (Slave SPI) mode, FPGA is as a slave device and is
+configured via SPI by an external Host.
+
+5.4.1 SSPI Mode Pins
+The SSPI configuration pins are shown in Table 5-12.
+Table 5-12 SSPI Mode Pins
+Pin Name
+RECONFIG_N
+
+READY
+
+I/O
+
+DONE
+
+I/O
+
+MODE[2:0]
+SCLK
+CLKHOLD_N
+SO
+SI
+SSPI_CS_N
+
+UG290-2.3E
+
+I/O
+I,
+Internal
+weak
+pull-up
+
+I,
+Internal
+weak
+pull-up
+I
+I,
+Internal
+weak
+pull-up
+O
+I
+I,
+Internal
+weak
+pull-up
+
+Description
+Low level pulse: Start GowinCONFIG
+High level: FPGA can be programmed and
+configured
+Low level: Programming configuration for FPGA
+is prohibited
+High-level pulse: Successfully programmed and
+configured;
+Low-level pulse: Programming and configuration
+uncompleted or failed.
+Configuration mode selection, READY rising
+edge sampling
+Input clock
+High level: SPI operation corresponding to
+SCLK is valid
+Low level: SPI operation corresponding to SCLK
+is invalid
+FPGA outputs data to Host
+Input data to FPGA from Host
+SSPI Chip selection signal, active low.
+
+49(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+5.4.2 SSPI Configuration Timing
+See Figure 5-30 for the SSPI timing.
+Figure 5-30 SSPI Configuration Timing
+
+See Table 5-13 for the SSPI configuration timing parameters.
+Table 5-13 SSPI Configuration Timing Parameters
+Name
+
+Description
+
+Min.
+
+Max.
+
+Tsclkp
+
+SCLK clock period
+
+15ns
+
+-
+
+Tsclkh
+
+SCLK clock high time
+
+7.5ns
+
+-
+
+Tsclkl
+
+SCLK clock low time
+
+7.5ns
+
+-
+
+Tsspis
+
+SSPI PORT setup time
+
+2ns
+
+-
+
+Tsspih
+
+SSPI PORT hold time
+
+0ns
+
+-
+
+Tsclkftco
+
+Time from SCLK falling edge to output
+
+-
+
+10ns
+
+Tsclkftcx
+
+Time from SCLK falling edge to high impedance
+
+-
+
+10ns
+
+Tcsnhw
+
+CSN high time
+
+25ns
+
+-
+
+Treadytcsl
+
+Time from READY rising edge to CSN low
+Time from READY rising edge to first SCLK
+edge
+
+TBD
+
+Treadytsclk
+
+TBD
+
+-
+
+Other than the power requirements, the following conditions need to
+be met to use the SSPI configuration mode:
+
+
+
+
+SSPI port enable
+RECONFIG_N is not set as a GPIO during the first configuration after
+power up or the previous programming.
+Initiate new configuration
+Power up again or trigger RECONFIG_N at one low pulse.
+
+5.4.3 Configuration Instruction
+In Slave SPI mode, you can program FPGA SRAM or read ID
+information on ID CODE\USER CODE\STATUS CODE through SSPI..
+External memory can also be programmed (Such as SPI Flash).
+The SSPI instruction of FPGA is generally composed of 1-4 bytes,
+UG290-2.3E
+
+50(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+including at least 1 instruction class byte and multiple redundant
+information bytes. If there is no specified information byte, the redundant
+information byte can be any number (0x00 is used in the following table).
+Table 5-14 Configuration Instruction
+
+Name
+
+Complete Instruction (Instruction Byte +
+Redundant Information Byte)
+
+Read ID Code
+
+0x11000000
+
+Read User Code
+
+0x13000000
+
+Read Status Code
+
+0x41000000
+
+Reconfig/Reprogram
+
+0x3C00
+
+Write Enable
+
+0x1500
+
+Write Disable
+
+0x3A00
+
+Write Data
+
+0x3B
+
+Program SPI Flash
+
+0x1600
+
+Init Address
+
+0x1200
+
+Erase SRAM
+
+0x0500
+
+Read ID Code
+The length of FPGA ID Code is 32bits. The instruction to read ID is four
+bytes, that is 0x11000000. Before sending instructions, keep CS at a high
+level and generate multiple clocks (more than two) to let FPGA get CS
+state.
+After CS is pulled down, the instruction of 0x11000000 is written in in
+MSB way and after this, 32 clocks are generated continuously. At this time,
+the ID CODE data will be successively shifted out of DO in the form of
+MSB.
+Figure 5-31 Read ID Code Timing
+
+UG290-2.3E
+
+51(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+The operation of reading Status Code / User Code is similar to the
+operation of reading ID Code, just replace the corresponding instructions.
+Write Enable (0x1500)
+Before configuring SRAM (writing features), enter programming mode
+using “Write Enable (0x15)” instruction to receive the “Write Data (0x3B)”
+instructions.
+Figure 5-32 Write Enable (0x15) Timing
+
+Note!
+At CS high level, more than two clocks should be given to SCLK to drive FPGA to identify
+CS signal. This rule also applies to other instructions.
+
+Write Disable (0x3A00)
+After finishing sending data, exit programming mode using Write
+Disable. After exiting, the device can be awakened to enter the working
+state.
+Figure 5-33 Write Disable(0x3A00) Timing
+
+UG290-2.3E
+
+52(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+The timing of 0x1500 and 0x3A is basically the same. Instructions start
+at CS low level and the CS is pulled up after the instruction transmission is
+completed. Instructions following this timing are as follows: 0x3C00
+(Reconfig / Reprogram), 0x1500(Write Enable), 0x3A000 (Write Disable),
+0x1600(Program SPI Flash), 0x1200(Init Address), 0x0500(Erase SRAM).
+In addition, SSPI is driven by an external clock, so if CS is at high
+before and after these instructions, more than two clocks are needed to
+enable FPGA to collect the state of CS.
+Write Data (0x3B)
+The fs file is sent directly to the FPGA device using the ”Write Data
+(0x3B)” instruction.
+Note that CS keeps low level in the process of data writing.
+Figure 5-34 Write Data (0x3B) Timing
+
+UG290-2.3E
+
+53(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+5.4.4 Connection Diagram for SSPI Configuration Mode
+The connection diagram for configuring Gowin FPGA products via
+SSPI is shown in Figure 5-35.
+Figure 5-35 SSPI Configuration Mode Connection Diagram
+Host
+CLK
+
+FPGA
+SCLK
+
+DIN
+
+SO
+
+DOUT
+
+SI
+
+CTRL
+
+CLK_HOLDN
+
+CS_N
+
+SSPI_CS_N
+
+Note!
+The figure above shows the minimum system diagram for the SSPI configuration. The
+value of the SSPI MODE is "001". The connection of the other fixed pins is shown in
+Figure 5-1.
+
+In addition to SRAM, SSPI can be used to program external SPI Flash.
+The MODE value of the Flash programming is the same as the MODE
+value of SSPI configuration mode. Configuration data can be written to
+SRAM or an external Flash using Gowin programmer. The connection
+diagram for programming an external Flash via SSPI is shown in Figure
+5-36.
+Figure 5-36 Connection Diagram of Programming External Flash via SSPI
+Host
+
+FPGA
+
+CTRL
+
+CLKHOLD_N
+
+CLK
+
+SCLK
+
+Flash
+MCLK
+
+CLK
+
+MCS_N
+
+CS_N
+
+CS_N
+
+SSPI_CS_N
+
+DOUT
+
+SI
+
+MI
+
+DOUT
+
+DIN
+
+SO
+
+MO
+
+DIN
+
+Note!
+
+
+
+All Arora family devices support programming external Flash via SSPI.
+®
+For the LittleBee family devices, currently only GW1N(R)-9 supports programming
+external Flash via SSPI.
+
+Please refer to Figure 5-37 for the flow of programming external Flash
+via SSPI.
+First, send the "Program SPI Flash" (0x1600) instruction to FPGA via
+SSPI. After this, the FPGA can forward SSPI to Flash, and the SSPI on the
+Host side can directly access Flash. Then, it can be programmed according
+to Flash timing.
+Note that when reading data from Flash, the data being read back is
+delayed by one bit. For example, when SSPI reads Flash's ID Code, it
+needs to send an extra Clock to get the last bit.
+
+UG290-2.3E
+
+54(87)
+
+5 Configuration Mode Introduction
+
+5.4 SSPI
+
+Figure 5-37 The Flow of Programming External Flash via SSPI
+Start
+
+Transfer
+Program SPI Flash
+Instruction
+(0x1600)
+
+Program Flash
+following SPI timing
+
+End
+
+UG290-2.3E
+
+55(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+5.4.5 Multiple FPGA Connection View in SSPI Mode
+Figure 5-38 Multiple FPGA Connection Diagram 1
+
+Figure 5-39 Multiple FPGA Connection Diagram 2
+
+5.5 MSPI
+In MSPI (Master SPI) mode, FPGA is as a Master and reads bitstream
+data from the external Flash via SPI port to complete configuration.
+MSPI Configuration Process: Set the MODE pin to MSPI status, power
+on again or trigger RECONFIG_N at one low-level pulse, and the device
+will read bitstream data from the external Flash and complete configuration
+automatically.
+According to the MSPI configuration features, remote upgrade
+requirements can be implemented: After starting the FPGA, if an upgrade
+
+UG290-2.3E
+
+56(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+is required, users can remotely write the configuration data into the external
+Flash, and trigger RECONFIG_N or power up again to upgrade the system
+if the upgrade conditions are met.
+MSPI Mode Pins
+The configuration of the MSPI mode is shown in Table 5-15.
+Table 5-15 Pin Description in JTAG Configuration Mode
+Pin Name
+
+I/O
+
+Description
+
+RECONFIG_N
+
+I,
+Internal
+weak
+pull-up
+
+Low level pulse: Start GowinCONFIG
+
+I/O
+
+High-level pulse: The device can be programmed and
+configured;
+Low level: Programming configuration for device is
+prohibited
+
+DONE
+
+I/O
+
+High-level pulse: Successfully programmed and
+configured;
+Low-level pulse: Programming and configuration
+uncompleted or failed.
+
+MODE[2:0]
+
+I,
+Internal
+weak
+pull-up
+
+MODE select signal, READY rising edge sample
+
+MCLK
+
+O
+
+FPGA output clock
+
+MCS_N
+
+O
+
+Chip selection signal, active low.
+
+MO
+
+O
+
+FPGA outputs data to Slave
+
+MI
+
+I
+
+Input data to FPGA through Slave
+
+I
+
+READY signal rising edge sampling
+High level: Read SPI mode (SPI instruction:0x03)
+Low level: Fast Read SPI mode (SPI instruction:0x0B)
+
+READY
+
+FASTRD_N
+Note!
+
+The MSPI configuration mode clock frequency should not be greater than 70MHz. The
+Flash high-speed access mode and external pull-down FASTRD_N pin are required when
+the clock frequency is greater than 30MHz and less than 70 MHz. Leave the FASTRD_N
+pin floating if the clock frequency is less than 30 MHz.
+
+UG290-2.3E
+
+57(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+Connection Diagram for MSPI Configuration Mode
+The connection diagram for configuring Gowin FPGA products through
+MSPI is shown in Figure 5-40.
+Figure 5-40 Connection Diagram for MSPI Configuration Mode
+FPGA
+
+SPI Flash
+
+FASTRD_N
+MCLK
+
+CLK
+
+MCS_N
+
+CS_N
+
+MI
+
+DOUT
+
+MO
+
+DIN
+
+Note!
+The figure above shows the minimum system diagram for the MSPI MODE. The value of
+the MSPI MODE is "010" (GW1N(R)) and “000” (GW2A(R) ). The other fixed pins are
+shown in Figure 5-1. The FASTRD_N pin can remain floating in MSPI mode if the clock
+frequency is less than 30 MHz.
+
+The connection diagram for programming data to external Flash is
+shown in Figure 5-41. The connection diagram for programming external
+Flash via the SSPI interface is shown in Figure 5-36.
+Figure 5-41 Connection Diagram of JTAG Programming External Flash
+FPGA
+
+Flash
+
+JTAG PORT
+
+TDI
+
+MCLK
+
+CLK
+
+TCK
+
+MCS_N
+
+CS_N
+
+TMS
+
+MI
+
+DOUT
+
+TDO
+
+MO
+
+DIN
+
+4.7K
+
+Note!
+The figure above shows the minimum system diagram of programming external Flash via
+JTAG. The connection for the other fixed pins is shown in Figure 5-1 .
+
+Gowin FPGA products usually only support one time automatic MSPI
+configuration after power up. The GW1N (R)-9, GW2A (R)-18, and GW1NS
+series products are improved: GW2A (R)-18 series FPGA support retrying
+configuration once; GW1N (R)-9 and GW1NS FPGA support retrying
+UG290-2.3E
+
+58(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+configuration twice. When the MSPI fails to configure after power up, the
+device can be reconfigured automatically according to the retry times
+supported. The factors that can lead to a failed configuration include false
+ID validation, false CRC check, and false instruction. The user can specify
+the SPI Flash address for retrying configuration, and write it through the
+Gowin software interface. This feature greatly reduces the risk of
+configuration failure, and thereby, ensures higher reliability of the user
+design.
+MULTI BOOT
+The derivative concept of MULTI BOOT refers to the FPGA reading
+bitstream data from different addresses in one same external Flash.
+Currently, the Gowin Programmer software supports the ability to program
+multiple bitstream data to external Flash without erasure, and the initial
+programming address is 0. The loading address of the latter bitstream data
+is written in previous bitstream data and the configuration is completed by
+triggering RECONFIG_N to switch the data stream file under the condition
+that the device power is on. FPGA products that support MSPI all support
+this mode.
+Refer to the following steps for MULTI BOOT:
+1. Open "BitStream" in Gowin software. Input the start address for the
+next BitStream in the text box following "SPI Flash Address", as shown
+in Figure 5-42;
+Figure 5-42 Input the Start address for the Next BitStream
+
+2. Select the external Flash mode in Programmer, set the start address of
+BitStream. This address should be the same as the start address set in
+UG290-2.3E
+
+59(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+Step 1, as shown in Figure 5-43;
+Figure 5-43 Set the Programming Address for the External Flash
+
+3. Click "Save" to complete the setting of BitStream start address and
+programming address.
+4. Trigger RECONFIG_N at one low pulse to realize the switching of
+multiple BitStreams.
+Note!
+
+
+
+
+
+MULTI BOOT needs to trigger RECONFIG_N to switch the configuration data during
+power on, and the start address is reset after power down.
+You need to calculate the size of the bitstream data before using multiple
+configurations to ensure that the start address is not covered by the previous
+bitstream data;
+The lower 12 bits of an SPI Flash start address is invalid and the address space of
+ADDR [23:12] can be set by users.
+
+In addition to the introduction of configuring one FPGA via one Flash,
+Gowin FPGA products also support configuring multiple FPGAs with one
+Flash: The FPGA directly connected to the SPI Flash adopts MSPI mode,
+while the other FPGA devices use SSPI or SERIAL mode. For the specific
+operation, please refer to the following version. The connection diagram is
+shown in Figure 5-44.
+Note!
+Before configuring, set the MODE value of the FPGA to MSPI and SERIAL or MSPI and
+SSPI. Gowin FPGA products do not support the configuration of one FPGA with multiple
+Flashes.
+
+UG290-2.3E
+
+60(87)
+
+5 Configuration Mode Introduction
+
+5.5 MSPI
+
+Figure 5-44 Connection Diagram for Configuring Multiple FPGAs via Single Flash
+
+MSPI Configuration Timing
+MSPI Download Timing is as shown in Figure 5-45.
+Figure 5-45 MSPI Download Timing
+
+UG290-2.3E
+
+61(87)
+
+5.6 DUAL BOOT Configuration (Supported by LittleBee®
+Family Only)
+
+5 Configuration Mode Introduction
+
+Table 5-16 shows the timing parameters.
+Table 5-16 MSPI Configuration Timing Parameters
+Name
+
+Description
+
+Min.
+
+Max.
+
+Tmclkp
+
+MCLK clock period
+
+15ns
+
+-
+
+Tmclkh
+
+MCLK clock high time
+
+7.5ns
+
+-
+
+Tmclkl
+
+MCLK clock low time
+
+7.5ns
+
+-
+
+Tmspis
+
+MSPI PORT setup time
+
+5ns
+
+-
+
+Tmspih
+
+MSPI PORT hold time
+
+1ns
+
+-
+
+Tmclkftco
+
+Time from MCLK falling edge to output
+
+-
+
+10ns
+
+Treadytmcsl
+
+Time from READY rising edge to MCS_N low
+Time from READY rising edge to first MCLK
+edge
+
+100ns
+
+200ns
+
+2.8μs
+
+4.4μs
+
+Treadytmclk
+
+Other than the power requirements, the following conditions need to
+be met to use the MSPI configuration mode:
+
+
+
+
+MSPI port enable
+RECONFIG_N is not set as a GPIO during the first configuration after
+power up or the previous programming.
+Initiate new configuration
+Power-on again or trigger RECONFIG_N at one low pulse.
+
+Figure 5-46 Multiple FPGA Connection Diagram in MSPI Configuration Mode
+
+5.6 DUAL BOOT Configuration (Supported by LittleBee®
+Family Only)
+The DUAL BOOT mode is a configuration mode supported by the
+nonvolatile LittleBee® Family of FPGA products. In DUAL BOOT mode,
+FPGA first reads bitstream data from external Flash to complete
+configuration.
+
+UG290-2.3E
+
+62(87)
+
+5.6 DUAL BOOT Configuration (Supported by LittleBee®
+Family Only)
+
+5 Configuration Mode Introduction
+
+Note!
+In DUAL BOOT mode, when the external Flash is empty or non-existent, FPGA will try to
+read data from the built-in Flash.
+
+The specific MODE value needs to be selected for the DUAL BOOT
+MODE. No external connection is required for the built-in Flash. The
+connection diagram for reading from external Flash is the same as that of
+the MSPI mode. Please refer to Figure 5-40. In Dual BOOT mode, users
+can select where to save the configuration data required.
+The Dual BOOT mode supported by GW1NS-2/GW1NS-2C device is
+slightly different from that of the other LittleBee® family devices.
+GW1NS-2/GW1NS-2C has double built-in Flash, so
+GW1NS-2/GW1NS-2C switches between the two built-in Flash in Dual
+BOOT mode.
+The Dual Boot mode configuration flow is shown in Figure 5-47.
+Figure 5-47 Dual Boot Flow Chart
+start
+
+ready？
+N
+Y
+emFlash
+fail？
+
+N
+
+Y
+N
+
+exFlash
+fail？
+Y
+
+success
+
+fail
+
+end
+
+Note!
+When the MODE value is set to "110", the FPGA first attempts to configure from the
+external Flash.
+
+GW1N(R)-9 and GW1NS series products support four times
+configuration in all DUAL BOOT modes.
+
+
+
+
+
+
+UG290-2.3E
+
+Start from the preferred storage path and attempt three times; if all
+attempts fail, start from the other storage path. The embedded Flash
+can only be started at “0“ address;
+When the MODE value is "110", different startup addresses can be
+selected for the three attempts to start from external Flash. The startup
+address needs to be written to the bitstream through Gowin software in
+advance. If the configuration fails three times, the devices attempt to
+start from the built-in Flash.
+The GW1NS series of FPGA products support multiple restarts after
+failures, but the start address cannot be modified.
+
+63(87)
+
+5 Configuration Mode Introduction
+
+5.7 CPU Mode
+
+Note!
+The lower 12 bits of an SPI Flash startup address is invalid and the address space of
+ADDR [23:12] can be set by users.
+
+GW1N (R)-4 devices do not currently support automatic DUALBOOT
+configuration. Gowin provides users with DUAL BOOT configuration
+solution for these two devices. Please refer to TN101-1.0E_GW1N-4 FPGA
+Download DUAL BOOT Program for more details.
+
+5.7 CPU Mode
+In CPU mode, the Host configures Gowin FPGA products through the
+8-bit data bus interface. CPU mode pins are shown in Table 5-17.
+Table 5-17 CPU Mode Pins
+Pin Name
+RECONFIG_N
+
+READY
+
+I/O
+
+DONE
+
+I/O
+
+MODE[2:0]
+SCLK
+CLKHOLD_N
+
+UG290-2.3E
+
+I/O
+I, internal
+weak
+pull-up
+
+I, internal
+weak
+pull-up
+I
+I, internal
+weak
+pull-up
+
+WE_N
+
+I
+
+D[7:0]
+
+I/O
+
+Description
+Low level pulse: Start GowinCONFIG
+High-level pulse: The device can be programmed
+and configured;
+Low level: Programming configuration for device is
+prohibited
+High-level: Successfully programmed and
+configured;
+Low-level: Programming and configuration
+uncompleted or failed.
+Configuration mode selection, READY rising edge
+sampling
+Input clock
+High: CPU operation is valid
+Low: CPU operation is invalid
+Read-write enable
+0：Write
+1：Read
+Data I/O port: Used as input pin in CPU mode, and
+used as output pin after configuration for
+verification
+
+64(87)
+
+5 Configuration Mode Introduction
+
+5.8 SERIAL Mode
+
+The connection diagram for the CPU mode is shown in Figure 5-48.
+Figure 5-48 Connection Diagram for CPU Mode
+Host
+
+FPGA
+SCLK
+
+CLK
+DATA
+
+8
+
+D[7:0]
+
+WE_N
+
+WE_N
+
+CTRL
+
+CLK_HOLDN
+
+Note!
+The figure above shows the minimum system diagram of the CPU MODE. The MODE
+value is set to "111". The connections for the other fixed pins are shown in Figure 5-1.
+
+Other than the power requirements, the following conditions need to
+be met to use the CPU configuration mode:
+
+
+
+
+CPU port enable
+RECONFIG_N is not set as a GPIO during the first configuration after
+power up or the previous programming.
+Initiate new configuration
+Power-on again or trigger RECONFIG_N at one low pulse.
+
+5.7.1 Configuration Timing
+Before configuration, make sure that MODE[2: 0]=111, and DONE will
+be pulled up after configuration. If DONE or READY is pulled down, the
+configuration fails.
+In the configuration process, data bus D[7:0] is the MSB mode, and
+the FPGA reads the data at the SCLK rising edge.
+Figure5-49 CPU Mode Configuration Timing
+
+5.8 SERIAL Mode
+In SERIAL mode, Host configures Gowin FPGA products via serial
+interface. SERIAL is one of the configuration modes that use the least
+number of pins. The SERIAL mode can only write bitstream data to FPGA
+and cannot readback data from FPGA devices; as such, the SERIAL mode
+cannot read information on the ID CODE and USER CODE and status
+
+UG290-2.3E
+
+65(87)
+
+5 Configuration Mode Introduction
+
+5.8 SERIAL Mode
+
+register. A definition of the pins employed in the SERIAL mode is provided
+in Table 5-18.
+Table 5-18 Pin Definition in SERIAL Configuration Mode
+Pin Name
+RECONFIG_N
+
+I/O
+I, internal
+weak
+pull-up
+
+READY
+
+I/O
+
+DONE
+
+I/O
+
+MODE[2:0]
+SCLK
+DIN
+DOUT
+
+Description
+Low level pulse: Start GowinCONFIG
+High-level pulse: The device can be programmed
+and configured;
+Low level: Programming configuration for device
+is prohibited
+High-level: Successfully programmed and
+configured;
+Low-level: Programming and configuration
+uncompleted or failed.
+
+I, internal
+weak
+pull-up
+I
+I, internal
+weak
+pull-up
+
+Configuration mode selection, READY rising edge
+sampling
+Input clock
+Input data
+Output data, only used in SERIAL configuration
+mode when FPGA cascading.
+
+O
+
+The connection diagram for the SERIAL mode is shown in Figure 5-50.
+Figure 5-50 Connection Diagram for SERIAL Mode
+Host
+
+FPGA
+
+CLK
+
+SCLK
+
+DOUT
+
+DIN
+
+Note!
+The figure above shows the minimum system diagram of the SERIAL MODE. The MODE
+value is set to "101". The connection for the other fixed pins is shown in Figure 5-1.
+
+SERIAL Configuration Timing
+See Figure 5-51 for the timing of SERIAL mode.
+Figure 5-51 SERIAL Configuration Timing
+
+Table 5-19 shows the timing parameters.
+
+UG290-2.3E
+
+66(87)
+
+5 Configuration Mode Introduction
+
+5.9 I2C Mode
+
+Table 5-19 SERIAL Configuration Timing Parameters
+Name
+
+Description
+
+Min.
+
+Max.
+
+Tsclkp
+
+SCLK clock period
+
+15ns
+
+-
+
+Tserials
+
+SERIAL PORT setup time
+
+2ns
+
+-
+
+Tserialh
+
+SERIAL PORT hold time
+
+0ns
+
+-
+
+Treadytsclk
+
+Time from READY rising edge to first SCLK edge
+
+TBD
+
+-
+
+Other than the power requirements, the following conditions need to
+be met to use the SERIAL configuration mode:
+
+
+
+
+SERIAL port enable
+RECONFIG_N is not set as a GPIO during the first configuration after
+power up or the previous programming.
+Initiate new configuration
+Power-on again or trigger RECONFIG_N at one low pulse.
+
+5.9 I2C Mode
+In I2C Mode, Gowin FPGA products are configured by Host via I2C
+interface. I2C Mode is one of the configuration modes that use the least
+number of pins. The I2C mode can only write bitstream data to FPGA and
+cannot readback data from FPGA devices; as such, the I2C mode cannot
+read information on the ID CODE, USER CODE, status register and read
+back check. A definition of the pins employed in the I2C mode is provided in
+Table 5-20.
+Table 5-20 Pin Definition in SERIAL Configuration Mode
+Pin Name
+RECONFIG_N
+
+I/O
+I, internal
+weak
+pull-up
+
+READY
+
+I/O
+
+DONE
+
+I/O
+
+SCL
+
+I, internal
+weak
+pull-up
+I
+
+SDA
+
+I/O
+
+MODE[2:0]
+
+Description
+Low level pulse: Start GowinCONFIG
+High-level pulse: The device can be programmed
+and configured;
+Low level: Programming configuration for device
+is prohibited
+High-level: Successfully programmed and
+configured;
+Low-level: Programming and configuration
+uncompleted or failed.
+Configuration mode selection, READY rising edge
+sampling
+Input clock
+Input data or output ACK
+
+The connection diagram for the I2C mode is shown in Figure 5-52.
+
+UG290-2.3E
+
+67(87)
+
+5 Configuration Mode Introduction
+
+5.9 I2C Mode
+
+Figure 5-52 Connection Diagram for I2C Mode
+Host
+
+FPGA
+
+CLK
+
+SCLK
+
+DOUT
+
+DIN
+
+Note!
+2
+
+The figure above shows the minimum system diagram of the I C MODE. The MODE value
+is set to "100". The connection for the other fixed pins is shown in Figure 5-1.
+
+Figure 5-53 I2C Mode Timing
+
+I2C is a serial transmission bus, which transmits data according to the
+protocol shown in the figure above. Under normal status, both SDA and
+SCL are at high level.
+Table 5-21 I2C Configuration Timing Parameters
+Prameter
+
+Description
+
+S
+
+Start condition
+
+SCL is high level and SDA switches from high to low level.
+
+P
+
+Stop condition
+
+ADDRESS
+
+Address frame
+
+R/W
+
+Read/Write bit
+
+ACK
+
+ACK/NACK 位
+
+DATA
+
+Data
+
+SCL is high level and SDA jumps from low to high level.
+A unique 7-bit or 10-bit sequence for each slave device
+that identifies the slave device when the master device is
+about to communicate with it.
+Determines whether the master sends data to the slave (0)
+or reads data from the slave (1).
+Each frame in the message is followed by an ACK/NACK
+bit, and Gowin FPGA returns 0 if correct.
+A data has 8bits, and the most significant bit is sent first.
+
+All DATA on the I2C bus is transmitted in 8-bit bytes. Each byte sent by the
+transmitter, it releases the DATA line during the clock pulse 9, and the receiver sends
+back an answer signal.The response signal is a valid response bit (ACK bit) if it is low,
+indicating that the receiver has successfully received the byte. The response signal is
+a non-acknowledgement bit (NACK) if it is high, which generally indicates that the
+receiver did not succeed in receiving the byte. The requirement for the ACK feedback
+is that the receiver pulls the SDA line low during the low level prior to the 9th clock
+pulse and ensures a stable low level during the high level of the clock.If the receiver is
+the master, after it receives the last byte, it sends a NACK signal to notify the
+controlled sender to end the data transmission and releases the SDA line for the
+master receiver to send a stop signal.
+
+UG290-2.3E
+
+68(87)
+
+5 Configuration Mode Introduction
+
+5.9 I2C Mode
+
+Each bit of data transmitted on the I2C bus has a corresponding clock pulse (or
+synchronous control), that is, each bit of data is transmitted serially on the SDA bit by
+bit based on the SCL serial clock. During data transfer, the level on the SDA must
+remain stable, with the low level being data 0 and the high level being data 1, while
+the SCL is high.The level on the SDA is allowed to change state only while the SCL is
+low.Logic 0 has a low voltage level and Logic 1 has a high voltage level.As shown in
+the figure below.
+
+The list of I2C mode supported by Gowin FPGA devices is as shown in
+the table below.
+Mode
+
+Device
+GW1N-2
+（IDCode:0x0120681B）
+GW1N-2
+（IDCode:0x0120681B）
+
+SRAM
+Embedded
+Flash
+External
+Flash
+
+Frequency
+
+Address
+
+100Khz~1.33Mhz
+
+7'b1010_000
+
+1.33Mhz±1%
+
+7'b1011_000
+
+Note!
+2
+
+If you use I C to write Flash, the bitstream file needs to be conveted into specific bitstream
+file first. The conversion tool is included in Gowin Programmer, and the name after
+
+conversion is suffixed with ". I2C ".
+
+Other than the power requirements, the following conditions need to
+be met to use the I2C configuration mode:
+
+
+
+
+UG290-2.3E
+
+I2C port enable
+RECONFIG_N is not set as a GPIO during the first configuration after
+power up or the previous programming.
+Initiate new configuration
+Power-on again or trigger RECONFIG_N at one low pulse.
+
+69(87)
+
+6 Bitstream File Configuration
+
+6
+
+Bitstream File Configuration
+
+The features of Gowin FPGA products need to be configured and
+programmed using Gowin software. The settings mainly include
+configuration pins multiplexing options and bitstream data configuration
+options. This chapter describes the bitstream file configuration. For the
+details about the configuration pin reuse, please refer to 4.1.2
+Configuration Pin Multiplexing.
+To transfer the configuration data safely and accurately, the CRC
+calibration algorithm has been incorporated by default in the FPGA
+bitstream file, and the security bit is set. During the process of data
+configuration, input data is checked in real time. The wrong data cannot
+wake up the device, and the DONE signal is pulled down. After the
+configuration of the bitstream with security bit is complete, data readback
+cannot be performed.
+
+6.1 Configuration Options
+Please refer to Figure 6-1 for the related configuration data setting
+interface. The options include CRC enable, bit stream data compression,
+encryption key settings, security bit settings, MSPI configuration frequency
+selection, SPI Flash start address settings in multiple configuration modes,
+USER CODE setting, etc. The lower 12 bits of an SPI Flash startup
+address is invalid and the address space of ADDR [23:12] can be set by
+users.
+
+UG290-2.3E
+
+70(89)
+
+6 Bitstream File Configuration
+
+Figure 6-1 Configuration Options
+
+Note!
+The security bit setting is forcibly checked after Gowin software verifies the encryption key
+setting option. In addition to ensuring the data is secure during the transmission process,
+using these bitstream settings during configuration also prevents any readback, thereby
+ensuring maximum protection of user data.
+
+6.2 Configuration Data Encryption (Supported by Arora
+Family only)
+The Gowin Arora® Family of FPGA products support bitstream data
+encryption, using the 128 AES encryption algorithm. Please refer to the
+following steps for the data encryption configuration:
+1. Enter the encryption KEY (KEY) in Gowin software interface to
+generate the bitstream data;
+2. Enter the decryption key in Gowin Programmer;
+3. After encrypted bitstream data is loaded into the device, FPGA
+compares the data that has been loaded with the decrypt key values
+stored in advance.
+If data parsing succeeds, the device finishes configuration and begins
+to work; if data parsing fails, the device cannot work, and READY and
+DONE are pulled down.
+
+6.2.1 Definition
+
+
+UG290-2.3E
+
+AES encryption key: AES private key used in AES encryption algorithm,
+
+71(87)
+
+6 Bitstream File Configuration
+
+
+
+
+
+specified by users. Referred to as "key” in this manual.
+AES encryption key length: 128 bits;
+Key: An abbreviation for AES encryption key. GW2A(R) series of FPGA
+products offers an address with 128 bits length to store Key;
+Lock: To ensure the security of AES Key, it is used to control the read
+permissions for the Key. This operation is named as "lock" in this
+manual. When it's locked, all the read back data is 1.
+
+6.2.2 Enter Encryption KEY
+Refer to the steps below to write the encryption keys in Gowin
+software:
+1. Open the corresponding project in Gowin software;
+2. Select "Project > Configuration > Dual Purpose Pin" from the available
+menu options;
+3. Click "BitStream”, check "Enable Encryption (only support GW2A)" and
+input the key value, as shown in Figure 6-2.
+Figure 6-2 Encryption Key Setting Method
+
+After setting the encryption key successfully, write the decrypted key to
+the FPGA key storage area for the device to analyze the encrypted
+bitstream data to complete the configuration.
+
+6.2.3 Enter the Decrypt Key
+To input the decryption key, refer to the following steps:
+1. Open the Gowin programming software;
+UG290-2.3E
+
+72(87)
+
+6 Bitstream File Configuration
+
+2. Scan the FPGA device;
+3. Right-click on the device name and select "Configure Security";
+4. Enter the encrypted key value in the pop-up interface, click "write" and
+write the value to the FPGA, as shown in Figure 6-3.
+Figure 6-3 Setting the Decryption Key
+
+After the decryption key is written successfully, readback the written
+value via the "Read" button on the interface to verify.
+After the key is written successfully, users also can select to "lock" it in
+FPGA via the Lock command. Once you have performed this action, any
+read and write key operations will be invalid, the key value cannot be
+modified, and all read bits are all "1".
+After the decryption key is set, the encrypted bitstream data will only
+work when the data matches the decryption key. The key does not affect
+the non-encrypted bitstream data.
+Note!
+The initial value of the Gowin FPGA keys is 0. If a key value is changed to 1, it cannot be
+changed back to 0. For example, the key value written during an operation is
+00000000-00000000-00000000-00000001, and the last bit of the modified key must be 1.
+
+6.2.4 Programming Operation
+Gowin Programmer offers the tool for programming AES encryption
+key. Open this tool by clicking "Tools > Security" in Gowin Software, as
+shown in Figure 6-4.
+
+UG290-2.3E
+
+73(87)
+
+6 Bitstream File Configuration
+
+Figure 6-4 AES Security Configure
+
+
+
+
+
+This configuration contains the following three parts:
+Write: Write Key;
+Read: Read Key;
+Lock: Lock read and write access to the Key.
+
+Write
+1. Write the user-defined Key to the text box in the figure above;
+2. Click "Write" button;
+3. Return the validation result after running.
+Read
+Click "Read" button to validate the written AES encryption key again.
+The Key that is read from the tool will be displayed in the text box in the
+figure above.
+Lock
+Click "Lock" to lock the read and write permission of Key. If it is locked,
+the Key cannot be read or written.
+
+UG290-2.3E
+
+74(87)
+
+6 Bitstream File Configuration
+
+6.2.5 Programming Flow
+Figure 5-21 shows the flow of how to program or lock the AES key. All
+the flows are based on JTAG protocol.
+Check ID CODE
+Check the device ID to determine whether the JTAG protocol works
+properly and whether the programing object is correct to avoid
+misoperation.
+Figure 6-5 Prepare
+
+Start
+
+Check ID
+
+No
+
+Yes
+
+Transmit Read ID
+Command (0x11)
+
+Read 32 Bits
+
+ID match?
+
+No
+
+Stop
+
+Yes
+
+?
+
+UG290-2.3E
+
+The '?' sign can be:
+A: To read AES key flow
+B: To program AES key flow
+C: To lock AES key or Set Key2 selected flow
+
+75(87)
+
+6 Bitstream File Configuration
+
+Read AES Key
+Figure6-6 Read AES Key Flow
+
+A
+Transmit ISC Enable
+Command (0x15)
+
+Transmit Read Key
+Command (0x25)
+
+Delay
+100 ms
+
+Read 128 Bits
+
+Transmit ISC Disable
+Command (0x3A)
+
+Stop
+
+UG290-2.3E
+
+76(87)
+
+6 Bitstream File Configuration
+
+Program AES Key
+Figure 6-7 Program AES Key Flow
+
+B
+Transmit ISC Enable
+Command (0x15)
+
+Transmit Program EFuse
+Command (0x24)
+
+Transmit Program Key
+Command (0x29)
+
+Transmit 128bits
+
+Delay
+800 ms
+
+Transmit Read ID
+Command ( 0x11)
+
+Transmit ISC Disable
+Command (0x3A)
+
+Stop
+
+UG290-2.3E
+
+77(87)
+
+6 Bitstream File Configuration
+
+Lock AES Key
+Locking the AES Key prevents the Key leakage. After locking the AES
+Key, you will not be able to read and configure the AES Key.
+Figure 6-8 Lock AES Key Flow
+
+C
+Transmit ISC Enable
+Command (0x15)
+
+Transmit Program EFuse
+Command (0x24)
+
+note:
+Start the 2.5 V circuit to get the voltage ready
+before program efuse
+
+Transmit Security
+Command (0x23)
+
+Set data[127:125] as "1" and all others data bits as "0"
+Transmit 128 bits of data
+
+Delay
+800 ms
+
+note:
+Just transmit a command to end the 2.5v circuit
+,such as ReadID.
+
+Transmit Read ID
+Command ( 0x11)
+or others
+
+Transmit ISC Disable
+Command (0x3A)
+
+Stop
+
+6.3 Configuration File Size
+The Gowin bitstream format can be Text (ASCii) with annotations or
+Binary with no annotations. The file with a .fs suffix is a text format file.
+Lines beginning with “//” are annotations. The others is the bitstream data.
+The file with a .bin suffix is a binary format file, with no annotations. This
+binary format file is commonly used for embedded programming. Users
+can configure the bitstream file format in Gowin software.
+1. Open the Gowin software;
+UG290-2.3E
+
+78(87)
+
+6 Bitstream File Configuration
+
+2. On the Process tab, right click Place & Route and then click
+“Configuration > Bitstream”;
+3. In the options of Bitstream Format, select Text or Binary, as shown in
+Figure 6-9.
+Figure 6-9 Bitstream Format generation
+
+Gowin supports compressing bitstream data. The compression ratio is
+related to the user design. This manual only provides uncompressed
+configuration file sizes, as shown in Table 6-1.
+Table 6-1 Gowin FPGA Products Configuration File Size (Max.)
+
+LUT
+1,152
+4,608
+
+8,640
+20,736
+54,720
+
+Max. Configuration
+File Size
+84 KBytes
+217 KBytes
+435 KBytes
+887 KBytes
+2269 KBytes
+
+Note!
+The data in the table is the file size in binary format, and the configuration file is not
+compressed. If SPI Flash is used to store bitstream file, memory margin is required.
+
+6.4 Configuration File Loading Time
+Gowin FPGA can be used as Master to read bitstream files from Flash
+and configure SRAM, including Autoboot mode and MSPI mode. In
+Autoboot mode, FPGA reads bitstream files from internal Flash. In MSPI
+mode, FPGA reads bitstream files from external Flash. When the FPGA is
+powered on and ready, it starts to read bitstream files, and when the
+loading is done, the FPGA enters the User Logic state, as shown in the
+figure below.
+
+UG290-2.3E
+
+79(87)
+
+6 Bitstream File Configuration
+
+Both LittleBee® family and Arora family of GOWINSEMI FPGA devices
+support MSPI mode, that is, after the device is powered on, it can read
+bitstream files from the external SPI Flash and then
+complete the configuration. The default frequency of reading configuration
+file is 2.5 MHz. One bit is read at each SPI clock, so the required loading
+time can be calculated according to the file size. The clock frequency of
+reading SPI Flash in MSPI mode can be up to 125 MHz. Note that the
+FastRead_n pin should be grounded at the same time when Fast Read SPI
+（0x0B）is used.
+The LittleBee® family devices support not only MSPI mode, but also
+Autoboot mode. The loading frequency is 2.5 MHz by default, and Autoboot
+mode loads one byte (8 bits) per clock. The loading time varies depending
+on the configuration file size, load frequency, and per-clock loading width.
+Due to the different process of the embedded Flash, the maximum
+Autoboot loading frequency for different devices is also different. The
+specific maximum loading speed is as shown in Table 6-2 below.
+Table 6-2 Loading Frequency of Config File
+Device
+
+Max. Loading Frequency of
+Autoboot
+
+Max. Loading Frequency of
+MSPI
+
+GW2A-55/55C
+GW2A-18/18C
+GW2AR-18/18C
+
+–
+125 MHz
+
+GW2ANR-18C
+GW1N-1
+GW1N-1S
+
+26 MHz
+
+GW1NS-2
+GW1NSR-2
+GW1NS-2C
+
+33 MHz
+
+GW1NSR-2C
+
+120 MHz
+
+GW1NSE-2C
+GW1NZ-1
+GW1N-2
+
+UG290-2.3E
+
+40 MHz
+
+80(87)
+
+6 Bitstream File Configuration
+
+Device
+
+Max. Loading Frequency of
+Autoboot
+
+Max. Loading Frequency of
+MSPI
+
+GW1N-2B
+GW1NSER-4C
+GW1NS-4
+GW1NSR-4
+GW1NS-4C
+GW1NSR-4C
+GW1N-4B
+GW1NR-4B
+GW1NRF-4B
+GW1N-4
+GW1NR-4
+GW1N-6
+GW1N-9
+GW1N-9C
+GW1NR-9
+GW1NR-9C
+
+UG290-2.3E
+
+81(87)
+
+6 Bitstream File Configuration
+
+The bitstream file loading time in MSPI mode is as shown in Table 6-3.
+Table 6-3 Loading Time in MSPI Mode
+
+Number
+of LUT4
+
+Max.
+Configuration
+File
+
+1,152
+4,608
+8,640
+20,736
+54,720
+
+84 KBytes
+217 KBytes
+435 KBytes
+887 KBytes
+2269 KBytes
+
+Loading Time
+(ms, when
+Frequency
+=2.5 M z)
+275
+711
+1425
+2906
+7435
+
+Loading Time
+(ms, when
+Frequency
+=25 MHz)
+28
+71
+142
+290
+743
+
+Loading Time
+(ms, when
+Frequency
+=41.6 MHz)
+17
+42
+85
+174
+446
+
+Loading Time
+(ms, when
+Frequency
+=62.5 MHz)
+11
+28
+57
+116
+297
+
+The bitstream file loading time in Autoboot mode is as shown in Table
+6-4.
+Table 6-4 Loading Time in Autoboot Mode
+
+Number
+of LUT4
+
+Max.
+Configuration
+File
+
+1,152
+4,608
+8,640
+
+84 KBytes
+217 KBytes
+435 KBytes
+
+Loading Time (ms,
+when frequency
+=2.5 MHz, default
+frequency)
+34
+88
+178
+
+Loading Time (ms,
+when Frequency
+=25 MHz)
+
+Loading Time (ms,
+when Frequency
+=31.25 MHz)
+
+4
+9
+17
+
+3
+7
+14
+
+What is listed above is the reference of loading time. From power on to
+configuration completion of the device, in addition to the configuration time,
+there are also the power on time (Tramp) and initialization time of the
+device. The specific power on time is related to the power supply device.
+Therefore, the approximate time of FPGA from power on to loading
+completion can be calculated according to the following formula:
+Autoboot mode:
+T loading time = POR time + Number of Data Stream Bits /8/ Clock Cycle
+MSPI mode:
+T loading time = POR time + Number of Data Stream Bits /clock cycle
+T loading time = POR time + Number of Data Stream Bits /clock cycle
+
+UG290-2.3E
+
+82(87)
+
+7 Safety Precautions
+
+7
+
+Safety Precautions
+
+Security is a key factor for users to design FPGA. Combined with
+GOWINSEMI devices features, Gowin programmer offers a series of safety
+precautions, which provides a perfect security mechanism for users'
+bitstream data.
+Safety precautions consist of three stages:
+
+
+
+
+Before configuration, Gowin programmer checks the validity of the
+bitstream;
+During configuration, GOWINSEMI device verifies the accuracy of the
+transmission data in real time;
+After configuration, GOWINSEMI device enters the working state,
+masking any readback requests.
+The details of the three stages are as follows:
+
+Before Configuration
+Gowin programmer can be used to configure Gowin FPGA by
+following the steps outlined below.
+1.
+2.
+3.
+
+Connect the device that needs to be configured;
+Start Gowin programmer to start scanning, and the connected FPGA
+devices can be identified automatically;
+Select the bitstream and configuration mode to configure the device.
+
+During the process outlined above, Gowin programmer will read the
+connected device ID first, and then compare this with the bitstream ID that
+users selected. The configuration can only proceed when the two IDs are
+identical, or the bitstream selected by users will be regarded as illegal data,
+resulting in configuration failure.
+Note!
+GOWINSEMI products have specific IDs that distinguish them from the other series of
+products. The bitstream generated by Gowin Software contains an ID verification directive,
+as such, users only need to select the specific device when creating a new project.
+
+UG290-2.3E
+
+83(87)
+
+7 Safety Precautions
+
+During Configuration
+The device reads and verifies the bit stream ID first, and configuration
+starts if verification passes. To prevent bitstream modifications or possible
+transmission errors, GOWINSEMI devices adopt CRC to ensure bitstream
+is written in correctly. The specific process is outlined below.
+Following each address segment of the bitstream generated by Gowin
+software, CRC is added. GOWINSEMI devices generate CRC in the
+process of receiving data and compares them with the check codes
+received. If a CRC error is detected, any data transmitted following this
+error will be ignored. The "DONE" indicator will not light up after
+configuration, and the CRC error message will be displayed on the Gowin
+programmer interface.
+After Configuration
+After configuration, the device bitstream will be loaded to the SRAM or
+on-chip Flash according to the configuration mode selected. (On-chip Flash
+is supported by the LittleBee® Family of FPGA products only.)
+
+
+
+
+If the data is loaded to the SRAM, Gowin software will set the security
+bit automatically in the process of bitstream generation, and no user
+can read SRAMs.
+If the data is loaded to the on-chip Flash, the Flash will be configured
+as the AUTO BOOT mode after Flash configuration is complete. Any
+reading requests will be prohibited.
+
+The AUTO BOOT mode of the LittleBee® Family of FPGA products
+does not require external connections, so this greatly reduces the risk of
+data interception and provides the user with higher security. DUAL BOOT
+provides a selection for users with the option to write the configuration data
+to off-chip Flash as required.
+Note!
+GOWINSEMI takes no responsibility for the security of the off-chip Flash.
+
+UG290-2.3E
+
+84(87)
+
+8 Boundary Scan
+
+8
+
+Boundary Scan
+
+The boundary scan operation is an extension of the JTAG
+configuration mode. The scanning chains contain long chain and short
+chain. The long chain is mainly combined with BSDL file for device testing.
+The short chain is mainly used to erase and read and write the external
+Flash on the FPGA chain.
+To perform a boundary scan, follow the steps outlined below:
+1. Connect the FPGA development board to the PC and then power up;
+2. Open Gowin programmer and scan the connected devices;
+3. Double-click in the "Operation" field and select "External Flash Mode”
+and the related bscan operation, as shown in Figure 8-1.
+
+UG290-2.3E
+
+85(87)
+
+8 Boundary Scan
+
+Figure 8-1 Boundary Scan Operation Schematic Diagram
+
+The boundary scan operation can only be performed on the external
+Flash of FPGA and cannot be used to program the embedded Flash or
+SRAM. This operation is irrelevant with the FPGA MODE value, but it is
+slower than that of the external Flash programming via JTAG.
+
+UG290-2.3E
+
+86(87)
+
+9 SPI Flash Selection
+
+9
+
+SPI Flash Selection
+
+The external SPI Flash device operation instructions supported by
+Gowin FPGA products are shown in Table 9-1. The Mxic and Winbond
+products are all in accordance with the requirements. In principle, if the
+read instruction and the quick read instruction are as shown in Table 9-1,
+Gowin FPGA can read data from this Flash.
+Table 9-1 SPI Flash Operation Instruction
+Operation
+
+Instruction
+
+Read
+
+0x03
+
+Fast_Read
+
+0x0B
+
+Note!
+The Flash read instructions supported by Gowin FPGA must have at least one 03 or 0B.
+Use the regular reading instruction if the clock frequency is no higher than 30 MHz. Use
+the fast reading instruction if the clock frequency is higher than 30 MHz. Fast read
+requires the FASTRD_N pin to be pulled down, and the clock frequency cannot be higher
+than 70MHz.
+
+UG290-2.3E
+
+87(87)
+
+

--- a/definitions/UG292_GW1NS_Schematic_Manual.md
+++ b/definitions/UG292_GW1NS_Schematic_Manual.md
@@ -1,0 +1,1351 @@
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER
+Series of FPGA Products Schematic Manual
+Introduction
+You should follow some rules for circuit board design when using
+GW1NS & GW1NSR & GW1NSE & GW1NSER series of FPGA products.
+This manual describes the characteristics of GW1NS & GW1NSR &
+GW1NSE & GW1NSER series of FPGA products. The main contents of
+this manual are as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Power Supply
+JTAG
+MSPI
+Clock Pin
+Difference Pin
+READY, RECONFIG_N, DONE
+MODE
+JTAGSEL_N
+FASTRD_N
+Configure Dual-purpose Pin
+External Crystal Oscillator Circuit Reference
+Bank Voltage
+Configuration Modes Supported by Each Device
+MIPI
+ADC
+USB
+Pinout
+
+Power Supply
+Overview
+GW1NS & GW1NSR & GW1NSE & GW1NSER series of FPGA
+products support LX, UX and LV versions. The voltage includes core
+voltage (VCC), auxiliary voltage (VCCX) and bank voltage (VCCO).
+www.gowinsemi.com.en
+
+1(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+There is no linear voltage regulator in devices of LX version, and VCCX
+needs to be set to 1.8V. The I/O Bank voltage VCCO can be set to 1.2 V, 1.5
+V, or 1.8 V as required.
+There is linear voltage regulator in devices of UX, and VCCX can be set
+to 2.5 V or 3.3V. The I/O Bank voltage VCCO can be set to 1.2 V, 1.5 V, 1.8 V,
+2.5 V, or 3.3 V as required. It should be noted that VCCX needs to be greater
+than or equal to VCCO.
+There is no linear voltage regulator in devices of LV version, and VCCX
+can be set to 1.8V, 2.5V or 3.3V. The I/O Bank voltage VCCO can be set to
+1.2 V, 1.5 V, 1.8 V, 2.5 V, or 3.3 V as required.
+Note!
+LX and LX versions have the same functions, and the pins are compatible.
+
+Vcc of these three versions is 1.2V. VCCX is the auxiliary power, which
+is used to supply some circuits in the chip, supporting 1.8V, 2.5V and 3.3V.
+After the chip powers on, VCCX can be turned off. VCCO Bank can be set to
+1.2V, 1.5V, 1.8V, 2.5V, or 3.3V as required.
+Power Index
+The device can only operate when the power voltage is in the
+recommended range. Table 1 lists the recommended range.
+Table 1 Recommended Range
+Name
+
+Description
+
+Min.
+
+Max.
+
+VCC
+
+Core voltage
+
+1.14V
+
+1.26V
+
+1.14V
+
+1.89V
+
+VCCOx
+
+I/O Bank voltage for LX version
+I/O Bank voltage for UX version
+VCCX needs to be greater than or equal to VCCOx
+for UX version.
+I/O Bank voltage for LV version
+
+1.14V
+
+3.465V
+
+1.14V
+
+3.465V
+
+Auxiliary voltage for LX version
+Auxiliary voltage for UX version
+VCCX needs to be greater than or equal to VCCOx
+for UX version.
+Auxiliary voltage for LV version
+
+1.71V
+
+1.89V
+
+2.375V
+
+3.465V
+
+1.71V
+
+3.465V
+
+VCCX
+
+Power Consumption
+For specific density, packages, and resource utilization, you can use
+GPA tool to evaluate and analyze the power consumption.
+Power Rising Slope
+The reference for power-on time: 0.01mV/μs ~ 10mV/μs.
+Power Filter
+Each FPGA power input pin is connected to the ground with a 0.1uF
+ceramic capacitor.
+Noise processing should be noted at the input end of the V CC, and the
+www.gowinsemi.com.en
+
+2(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+specific is as follows:
+Figure 1 Noise Processing
+V1P2
+FB
+
+Vcc
+C
+4.7uF
+
+FB is a magnetic bead, and the reference model is MH2029-221Y. The
+ceramic capacitance is 4.7uF, and It offers an accuracy of more than ±20%.
+
+JTAG
+Overview
+JTAG interface is used for downloading the bitstream to SRAM,
+on-chip flash or off-chip flash of FPGA.
+Signal Description
+Table 2 Signal Description
+Name
+
+I/O
+
+Description
+
+TCK
+
+I
+I, internal weak
+pull-up
+I, internal weak
+pull-up
+O
+
+JTAG serial clock input
+
+TMS
+TDI
+TDO
+
+JTAG serial mode input
+JTAG serial data input
+JTAG serial data output
+
+JTAG Circuit Reference
+Figure 2 JTAG Circuit Reference
+R
+J
+4.7K
+
+TCK
+
+R
+
+22
+
+1
+
+2
+
+TDI
+
+R
+
+22
+
+3
+
+4
+
+TDO
+
+R
+
+22
+
+5
+
+TMS
+
+R
+
+22
+
+JTAG
+
+VCC3P3
+
+6
+
+7
+
+8
+
+9
+
+10
+
+Note!
+
+
+The resistance accuracy is not less than ±5%;
+
+
+
+The power of JTAG 6th pin can be set to VCC1P2, VCC1P5, VCC1P8, VCC2P5 as
+required.
+
+www.gowinsemi.com.en
+
+3(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+MSPI
+Overview
+FPGA as a master device, MSPI reads the data automatically from the
+off-chip flash then transmits it to the FPGA SRAM.
+Signal Description
+Table 3 Signal Description
+Name
+MCLK
+MCS_N
+MI
+MO
+
+I/O
+O
+O
+I
+O
+
+Description
+Clock output in MSPI mode
+MCS_N in MSPI mode, low-active
+Data input in MSPI mode
+Data output in MSPI mode
+
+MSPI Circuit Reference
+Figure 3 MSPI Circuit Reference
+
+VCC3P3
+
+U
+VCC3P3
+
+MCS_N
+
+1
+
+CS
+2 DO
+
+MI
+R
+
+R
+
+4.7K
+
+3
+4
+
+VCC
+HOLD
+
+WP
+
+CLK
+
+GND
+
+DI
+
+8
+
+C
+100nF
+
+4.7K
+
+7
+
+MCLK
+
+6
+
+MO
+
+5
+R
+
+SPI FLASH
+1K
+
+Note!
+
+
+MCLK signal requires 1K pull-down resistor.
+
+
+
+The resistance accuracy is not less than ± 5%.
+
+Clock Pins
+Overview
+
+
+
+
+www.gowinsemi.com.en
+
+The clock pins include GCLK global clock pins and PLL clock pins.
+GCLK: GCLK in FPGA products distributes in L and R quadrants. Each
+quadrant provides eight GCLK nets. The clock source of each GCLK
+can be dedicated pin or CRU, and the dedicated pin can provide better
+performance.
+PLL: Frequency (multiplication and division), phase, and duty cycle can
+be adjusted by configuring the parameters.
+
+4(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Signal Description
+Table 4 Signal Description
+Name
+
+I/O
+
+Description
+
+GCLKT_[x]
+
+I/O
+
+Pins in global clock input, T(True), [x]: global clock
+No.
+
+GCLKC_[x]
+
+I/O
+
+Pins for Global clock input, C(Comp), [x]: global
+clock No.
+
+LPLL_T_fb/RPLL_T_fb
+
+I
+
+Left/Right PLL feedback input pins, T(True)
+
+LPLL_C_fb/RPLL_C_fb
+
+I
+
+Left/Right PLL feedback input pins, C(Comp)
+
+LPLL_T_in/RPLL_T_in
+
+I
+
+Left/Right PLL clock input pin, T(True)
+
+LPLL_C_in/RPLL_C_in
+
+I
+
+Left/Right PLL clock input pin, C(Comp)
+
+Clock Input Selection
+If the external clock as PLL clock, it is recommended to input from
+PLL_T.
+GCLK is the global clock and is connected to all resources in the
+device. It is recommended to input from GCLK_T.
+
+Differential Pins
+Overview
+Differential transmission is a kind of signal transmission, which is
+different from the traditional signal line and ground line. Differential
+transmission signals are transmitted on these two lines. These two signals
+are with same amplitudeAmplitude, phase and opposite polarity.
+Differential Type
+Figure 5 Differential Type
+I/O output standard
+
+Single/Differ
+
+Bank VCCO (V)
+
+Output Driver Strength (mA)
+
+LVPECL33E
+
+Differential
+
+3.3
+
+16
+
+MVLDS25E
+
+Differential
+
+2.5
+
+16
+
+BLVDS25E
+
+Differential
+
+2.5
+
+16
+
+RSDS25E
+
+Differential
+
+2.5
+
+8
+
+LVDS25E
+
+Differential
+
+2.5
+
+8
+
+LVDS25
+
+Differential
+
+2.5/3.3
+
+3.5/2.5/2/6
+
+RSDS
+
+Differential
+
+2.5/3.3
+
+2
+
+MINILVDS
+
+Differential
+
+2.5/3.3
+
+2
+
+PPLVDS
+
+Differential
+
+2.5/3.3
+
+3.5
+
+SSTL15D
+
+Differential
+
+1.5
+
+8
+
+www.gowinsemi.com.en
+
+5(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+I/O output standard
+
+Single/Differ
+
+Bank VCCO (V)
+
+Output Driver Strength (mA)
+
+SSTL25D_I
+
+Differential
+
+2.5
+
+8
+
+SSTL25D_II
+
+Differential
+
+2.5
+
+8
+
+SSTL33D_I
+
+Differential
+
+3.3
+
+8
+
+SSTL33D_II
+
+Differential
+
+3.3
+
+8
+
+SSTL18D_I
+
+Differential
+
+1.8
+
+8
+
+SSTL18D_II
+
+Differential
+
+1.8
+
+8
+
+HSTL18D_I
+
+Differential
+
+1.8
+
+8
+
+HSTL18D_II
+
+Differential
+
+1.8
+
+8
+
+HSTL15D_I
+
+Differential
+
+1.5
+
+8
+
+
+
+Note!
+
+
+
+See pinout manuals for specific differential pin positions.
+
+READY, RECONFIG_N, DONE
+Overview
+RECONFIG_N, equivalent to the reset function of FPGA programming
+configuration, FPGA cannot perform any configuration operation when
+RECONFIG_N is pulled down.
+As a configuration pin, a low level with a pulse width of not less than
+25ns is required for GowinCONFIG configuration mode to enable the
+device to reload the bitstream. You can control the pin by writing logic to
+trigger the device to reconfigure as required.
+You can configure FPGA only when the READY signal is high. The
+device should be restored by power on or triggering RECONFIG_N when
+the READY signal is low.
+As an output configuration pin, it can indicate whether the FPGA can
+be configured currently. If the device is ready, READY signal is high. If the
+device fails to configure, the READY signal changes to low. As an input
+configuration pin, you can delay the configuration by its own logic or pulling
+down the READY signal.
+DONE signal indicates that the FPGA is configured successfully. The
+signal is high after successful configuration.
+As an output configuration pin, it can indicate whether FPGA
+configuration is successful. If configured successfully, DONE is high, and
+the device enters into an operating state. If the device failed to configure,
+the DONE signal remains low. As the input, you can delay the entry into
+user mode by manually pulling down the DONE signal via the logic.
+When RECONFIG_N or READY signals are low, DONE signal is also
+low. When configuring SRAM using JTAG circuit, it does not need to take
+DONE signal into account.
+
+www.gowinsemi.com.en
+
+6(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Signal Description
+Table 6 Signal Description
+Name
+
+I/O
+
+Description
+
+RECONFIG_N
+
+I, internal
+pull-up
+
+weak
+
+Low level pulse: start new GowinCONFIG
+configuration
+High-level pulse: The device
+programmed and configured;
+
+READY
+
+can
+
+be
+
+I/O
+Low-level pulse: The device cannot be
+programmed and configured,
+High-level pulse: Successfully programmed
+and configured;
+
+DONE
+
+I/O
+Low-level
+pulse:
+Programming
+configuration uncompleted or failed.
+
+and
+
+READY, RECONFIG_N, DONE Reference Circuit
+Figure 4 READY, RECONFIG_N, DONE Reference Circuit
+VCC3P3
+
+R
+READY
+
+R
+
+R
+
+4.7K 4.7K 4.7K
+
+RECONFIG_N
+DONE
+D
+
+Note!
+
+
+The pull-up power supply is the bank voltage value VCCO0 of the corresponding pin;
+
+
+
+The resistance accuracy is not less than ± 5%;
+
+MODE
+Overview
+MODE includes MODE0, MODE1, MODE2, and GowinCONFIG.
+When FPGA powers on or a low pulse triggers RECONFIG_N, the device
+enters the corresponding GowinCONFIG state according to the MODE
+value. As the number of pins for each package is different, some MODE
+pins are not all packaged, and the unpacked MODE pins are grounded
+inside. Please refer to the corresponding pinout manual for further details.
+
+www.gowinsemi.com.en
+
+7(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Signal Description
+Table 7 Signal Description
+Name
+
+I/O
+
+Description
+
+MODE2
+
+I, internal weak
+pull-up
+
+GowinCONFIG mode selection pin.
+
+MODE1
+
+I, internal weak
+pull-up
+
+GowinCONFIG modes selection pin.
+
+MODE0
+
+I, internal weak
+pull-up
+
+GowinCONFIG mode selection pin.
+
+Mode Selection
+Table 8 Mode Selection
+Configuration Mode
+
+MODE[2:0]
+
+JTAG
+
+XXX
+AUTO
+BOOT
+
+000
+
+SSPI
+
+001
+
+MSPI
+
+010
+
+DUAL
+BOOT
+
+110
+
+SERIAL
+
+101
+
+CPU
+
+111
+
+GowinCONFIG
+
+Description
+External Host configure FPGA products of
+LittleBee® Family via JTAG interface.
+FPGA reads data from embedded Flash
+for configuration
+External Host configure FPGA products of
+LittleBee® Family via SPI interface.
+FPGA as Master, FPGA reads data from
+external Flash (or other devices) via the
+SPI interface for configuration..
+FPGA reads data from external Flash first
+and if the external Flash fails, it reads from
+the internal Flash.
+External Host configure FPGA products of
+LittleBee® Family via DIN interface.
+External Host configure FPGA products of
+LittleBee® Family via DBUS interface.
+
+JTAGSEL_N
+Overview
+JTAGSEL_N is JTAG mode selection signal. If the JTAG pin is set to
+GPIO in Gowin software, the JTAG pin changes to GPIO after the device is
+powered on to configure successfully. If JTAG configuration fails, you can
+recover by pulling down JTAGSEL_N. If you do not set JTAG multiplexing,
+the JTAG configuration function is always available.
+Signal Description
+Table 9 Signal Description
+Pin Name
+
+I/O
+
+Description
+
+JTAGSEL_N
+
+I, internal weak
+pull-up
+
+Change JTAG pin from GPIO to
+configuration pin, active-low
+
+Note!
+
+www.gowinsemi.com.en
+
+8(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+The JTAGSEL_N pin and four JTAG pins (TCK, TMS, TDI, and TDO) configured as GPIO
+are exclusive. JTAG pins can only be used as configuration pin if JTAGSEL_N is set to
+GPIO. JTAGSEL_N can only be used as a configuration pin if JTAG pins are set to GPIOs.
+
+FASTRD_N
+Overview
+MSPI configuration mode reads the SPI Flash speed selection signal.
+When FASTRD_N is high, it is normal read mode. When FASTRD_N is low,
+it is high speed read mode. Different manufacturers have different
+high-speed read operation instructions, please refer to the corresponding
+Flash datasheet.
+Signal Description
+Table 10 Signal Description
+Pin Name
+
+FASTRD_N
+
+I/O
+
+Description
+
+
+As a configuration pin, internal weak pull-up,
+READY signal rising edge samples MSPI
+configuration speed mode;
+
+
+
+As a GPIO, it can be used as input or output.
+
+I/O
+
+Note!
+
+
+High level: Normal Flash mode, clock frequency should not be higher than 30MHz;
+
+
+
+Low level: High speed Flash mode, clock frequency should be > 30MHz and <
+80MHz
+
+Configure Dual-purpose Pin
+Overview
+Dual-purpose pin configuration refers to performing configuration
+function at the moment of power-on. After downloading bitstream files, it is
+used as general I/O.
+The steps are as follows:
+1. Open the project in Gowin software;
+2. Select "Project > Configuration > Dual Purpose Pin" from the menu, as
+shown in Figure 5;
+3. Check the corresponding options.
+
+www.gowinsemi.com.en
+
+9(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Figure 5 Configure Dual-purpose Pin
+
+Dual- purpose Pin
+
+
+
+
+
+
+
+
+
+
+
+SSPI: As a GPIO, SSPI can be used as input or output;
+MSPI: As a GPIO, MSPI can be used as input or output;
+RECONFIG_N GPIO can only be used as an output. Set the initial
+value of RECONFIG_N as high when multiplexing it.
+READY: As a GPIO, READY can be used as input or output. As an
+input GPIO, the initial value of READY should be 1. Otherwise, the
+FPGA will fail to configure;
+As a GPIO, DONE can be used as an input or output. If DONE is used
+as an input GPIO, the initial value of DONE should be 1. Otherwise, the
+FPGA will fail to enter the user mode after configuring;
+As a GPIO, JTAG can be used as an input or output;
+As a GPIO, JTAGSEL_N can be used as an input or output.
+As a GPIO, JTAG can be used as an input or output. You multiplex
+MODE pin, the correct value is needed to provided during configuration
+(power-on or low-level pulse triggers RECONFIG_N). Up to three pins
+can be multiplexed in MODE. Unpackaged pins are grounded internally.
+Please refer to pinout manuasl for details. For the MODE value
+corresponding to different configuration modes, please refer to the
+corresponding device manual.
+Note!
+If the number of I/O ports is sufficient, use non-multiplexed pins first.
+
+www.gowinsemi.com.en
+
+10(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+FPGA External Crystal Oscillator Circuit Reference
+Figure 6 FPGA External Crystal Oscillator Circuit
+VCC3P3
+
+FB
+C
+1
+2
+
+IN
+
+4
+VCC
+
+GND
+
+OUT 3
+
+R
+
+10nF
+
+22 CLK_G
+
+OSC
+
+FB is a magnetic bead, and MH2029-221Y is the reference model. The
+resistance accuracy is not less than ±5% , and capacitance accuracy is not
+less than ±20%.
+
+Bank Voltage
+For the Bank power supply requirements of the devices, please refer
+to the Power section of the following documents.
+
+
+
+
+
+
+
+
+
+UG825, GW1NS-2C Pinout
+UG822, GW1NS-2 Pinout
+UG824, GW1NS-4 & 4C Pinout
+UG862, GW1NSR-2 & 2C Pinout
+UG864, GW1NSR-4 Pinout
+UG865, GW1NSR-4C Pinout
+UG872, GW1NSE-2C Pinout
+UG883, GW1NSER-4C Pinout
+
+Configuration Modes Supported by Each Device
+GW1NS-2
+Table 11 GW1NS -2 Configuration Modes
+Modes
+
+JTAG
+
+QN32
+QN32U
+CS36
+CS36U
+QN48
+LQ144
+
+√
+√
+√
+√
+√
+√
+
+www.gowinsemi.com.en
+
+AUTO
+BOOT
+√
+√
+√
+√
+√
+√
+
+DUAL
+BOOT
+√
+
+MSPI
+
+SSPI
+
+SERIAL
+
+CPU
+
+-
+
+√
+√
+
+√
+
+√
+
+11(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+GW1NS-2C
+Table 12 GW1NS -2 C Configuration Modes
+Modes
+
+JTAG
+
+QN32
+QN32U
+CS36
+QN48
+LQ144
+
+√
+√
+√
+√
+√
+
+AUTO
+BOOT
+√
+√
+√
+√
+√
+
+DUAL
+BOOT
+√
+
+MSPI
+
+SSPI
+
+SERIAL
+
+CPU
+
+-
+
+√
+√
+
+√
+
+√
+
+GW1NS-4/4C
+Table 13 GW1NS-4 / 4C Configuration Modes
+Configuration Modes
+CS49
+QN48
+MG64
+
+JTAG
+√
+√
+√
+
+AUTO BOOT
+√
+√
+√
+
+MSPI
+√
+-
+
+GW1NSR-2/2C
+Table 14 GW1NSR-2 / 2 C Configuration Modes
+Configuration Modes
+QN48
+
+JTAG
+√
+
+AUTO BOOT
+√
+
+GW1NSE-2C
+Table 15 GW1NSE -2 C Configuration Modes
+Configuration Modes
+QN48
+LQ144
+
+JTAG
+√
+√
+
+AUTO BOOT
+√
+√
+
+GW1NSER-4C
+Table 16 GW1NSER -4 C Configuration Modes
+Configuration Modes
+QN48G
+QN48P
+
+JTAG
+√
+√
+
+AUTO BOOT
+√
+√
+
+GW1NSR-4C
+Table 17 GW1NSR -4 C Configuration Modes
+Configuration Modes
+MG64P
+
+JTAG
+√
+
+AUTO BOOT
+√
+
+MIPI
+GW1NS series of FPGA products support embedded MIPI interface
+modules. BANK0 of GW1NS-2 is MIPI input port and BANK2 is MIPI output
+www.gowinsemi.com.en
+
+12(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+port. BANK0/BANK1 of GW1NS-4 is MIPI input and BANK2 supports MIPI
+output.
+Note!
+
+
+For GW1NS-2C/2 devices of LX or UX version, VCCO0 is set to 1.2V when BANK0 is
+used as MIPI input and VCCO2 is set to 1.2V when BANK2 is used as MIPI output. And
+the MIPI speed of LX version is only 60% of that of UX version.
+
+
+
+When BANK0/BANK1 of GW1NS-4C/4 is used as MIPI input, VCCO0/VCCO1 need to be
+set to 1.2V, and when BANK2 is used as MIPI output, VCCO2 needs to be set to 1.2V;
+When VCCX is set to 1.8 V, the speed of MIPI can only reach 60% of the speed of MIPI
+when VCCX is set to 2.5V/3.3V.
+
+ADC
+GW1NS-2C/2 series of FPGA products integrate an eight-channel
+single-ended 12 bits SAR ADC. It is a medium-speed ADC with low-power,
+low-leakage current and high-speed.
+Dynamic Performance
+
+
+Slew Rate: Max. 1MHz
+
+
+
+Dynamic range: >81 dB SFDR，>62 db SINAD
+
+
+
+Linear performance: INL<1 LSB, DNL<0.5 LSB, no missing codes
+
+ADC Reference Voltage
+
+
+
+
+The reference voltage can be enabled or disabled by configuring
+parameters.
+VREF_EN=1, enabled;
+VREF_EN=0, disabled, and Vref is provided by Vccx.
+When Vref is enabled, there are two ways to provide Vref: internal and
+external.
+The internal is provided by Vccx and supports seven reference
+voltages by configuring VREF_SEL. The external is provided by VREF.
+
+Note!
+
+
+It is recommended to add 10uF capacitance for ADC signal pin.
+
+
+
+It is recommended to use external reference voltage
+
+USB
+GW1NS-2C/2 is embedded with USB2.0 PHY with 480Mbps, USB1.1
+1.5/12Mbps compatible, plug-and-play, hot-plug.
+Note!
+
+
+The VBUS pin of FPGA chip needs to be connected to the VBUS of USB connector.
+
+
+
+The ID pin of FPGA chip needs to be connected to the ID of USB connector.
+
+
+
+The XIN and XOUT pins of FPGA chip need to be connected to the external 12Mhz
+crystal.
+
+
+
+The REXT pin of FPGA chip must be connected to the pull-down 12.7K with
+resistance of 1% accuracy.
+
+www.gowinsemi.com.en
+
+13(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Pinout
+Before the design of the circuit, you should take the FPGA pinout into
+consideration, and a reasonable choice should be made for IO LOGIC,
+global clock resource, PLL and differential signals, etc.
+Note!
+During the configuration, all I/O (except TCK) of the device is weak pull-up, and I/O status
+after configuration is controlled by user programs and constraints.
+
+www.gowinsemi.com.en
+
+14(15)
+
+GW1NS & GW1NSR & GW1NSE & GW1NSER Series of FPGA
+Products Schematic Manual
+UG292-1.0E
+
+Support and Feedback
+Gowin Semiconductor provides customers with comprehensive
+technical support. If you have any questions, comments, or suggestions,
+please feel free to contact us directly by the following ways.
+Website: www.gowinsemi.com
+E-mail: support@gowinsemi.com
+Revision History
+Date
+
+Version
+
+Description
+
+07/28/2020
+
+1.0
+
+Initial version published.
+
+www.gowinsemi.com.en
+
+15(15)
+
+Copyright© 2020 Guangdong Gowin Semiconductor Corporation. All Rights Reserved.
+No part of this document may be reproduced or transmitted in any form or by any denotes,
+electronic, mechanical, photocopying, recording or otherwise, without the prior written
+consent of GOWINSEMI.
+Disclaimer
+GOWINSEMI®, LittleBee®, Arora, and the GOWINSEMI logos are trademarks of
+GOWINSEMI and are registered in China, the U.S. Patent and Trademark Office, and other
+countries. All other words and logos identified as trademarks or service marks are the
+property of their respective holders, as described at www.gowinsemi.com. GOWINSEMI
+assumes no liability and provides no warranty (either expressed or implied) and is not
+responsible for any damage incurred to your hardware, software, data, or property resulting
+from usage of the materials or intellectual property except as outlined in the GOWINSEMI
+Terms and Conditions of Sale. All information in this document should be treated as
+preliminary. GOWINSEMI may make changes to this document at any time without prior
+notice. Anyone relying on this documentation should contact GOWINSEMI for the current
+documentation and errata.
+
+

--- a/definitions/UG865_GW1NSR_4C_Pinout.md
+++ b/definitions/UG865_GW1NSR_4C_Pinout.md
@@ -1,0 +1,268 @@
+# Version History
+
+| Data | Version | Description |  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 10/15/2019 | 1.0E | Initial version published.                                                                                                          |  |  |  |  |  |
+| 04/16/2020 | 1.01E | Pin 25 of QN48P and QN48G modified. |  |  |  |  |  |
+| 05/29/2020 | 1.02E | The pin description of GCLK updated;<br>VCCO0/VCCO1 range when using FLASH updated. |  |  |  |  |  |
+
+# Pin Definitions
+
+| Pins Name | Direction | Description |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- |
+| User I/O Pins |  |  |  |  |  |  |
+| IO [End][Row/Column Number][A/B] | I/O | [End] indicates the pin location, including L(left) R(right) B(bottom), and T(top) |  |  |  |  |
+|  |  | [Row/Column Number] indicates the pin Row/Column number.<br>If [End] is T(top) or B(bottom), the pin indicates the Column number of the corresponding CFU.<br>If [End] is L(left) or R(right),  the pin indicates the Row number of the corresponding CFU. |  |  |  |  |
+|  |  | [A/B] indicaties differential signal pair information. |  |  |  |  |
+| Multi-Function Pins |  |  |  |  |  |  |
+| IO [End][Row/Column Number][A/B]/MMM |  | /MMM represents one or more of the other functions in addition to being general purpose user I/O.<br>When not used for the specical functions, these pins can be user I/O. |  |  |  |  |
+| RECONFIG_N | I,Internal Weak Pull Up | Starat new GowinCONFIG mode when low pulse |  |  |  |  |
+| READY | I/O | When high, device can be programmed and configured |  |  |  |  |
+|  |  | When low, device cannot be programmed and configured |  |  |  |  |
+| DONE | I/O | High indicates successful completion of programming and configuration |  |  |  |  |
+|  |  | Low indicates unfinished or failure of programming and configuration  |  |  |  |  |
+| FASTRD_N/D3 | I/O | In MSPI mode, FASTRD_N is used as Flash access speed port. <br>Low indicates high-speed Flash access mode; high indicates regular Flash access mode. |  |  |  |  |
+|  |  | Data port D3 in CPU mode |  |  |  |  |
+| MCLK/D4 | I/O | Clock output MCLK in MSPI mode |  |  |  |  |
+|  |  | Data port D4 in CPU mode |  |  |  |  |
+| MCS_N/D5 | I/O | Enable signal MCS_N in MSPI mode, active-low |  |  |  |  |
+|  |  | Data port D5 in CPU mode |  |  |  |  |
+| MO/D6 | I/O | MOSI in MSPI mode:Master data output/Slave data input |  |  |  |  |
+|  |  | Data port D6 in CPU mode |  |  |  |  |
+| MI/D7 | I/O | MISO in MSPI mode:Master data input/Slave data output |  |  |  |  |
+|  |  | Data port D7 in CPU mode |  |  |  |  |
+| SSPI_CS_N/D0 | I/O | Enable signal SSPI_CS_N in SSPI mode, active-low |  |  |  |  |
+|  |  | Data port D0 in CPU mode |  |  |  |  |
+| SO/D1 | I/O | MISO in MSPI mode:Master data input/Slave data output |  |  |  |  |
+|  |  | Data port D1 in CPU mode |  |  |  |  |
+| SI/D2 | I/O | MOSI in SSPI mode:Master data output/Slave data input |  |  |  |  |
+|  |  | Data port D2 in CPU mode |  |  |  |  |
+| TMS | I | Serial mode input in JTAG mode |  |  |  |  |
+| TCK | I | Serial clock input in JTAG mode |  |  |  |  |
+| TDI | I | Serial data input in JTAG mode |  |  |  |  |
+| TDO | O | Serial data output in JTAG mode |  |  |  |  |
+| JTAGSEL_N | I, Internal Weak Pull Up | JTAG mode selection, active-low |  |  |  |  |
+| SCLK | I | Clock input in SSPI, SERIAL, and CPU modes |  |  |  |  |
+| DIN | I, Internal Weak Pull Up | Data input in SERIAL mode |  |  |  |  |
+| DOUT | O | Data output in SERIAL mode |  |  |  |  |
+| CLKHOLD_N | I, Internal Weak Pull Up | High, SCLK will be connected internally in SSPI mode or CPU mode |  |  |  |  |
+|  |  | Low, SCLK will be disconnected from SSPI mode or CPU mode |  |  |  |  |
+| WE_N | I | Select data input/output of D[7:0] in CPU mode |  |  |  |  |
+| GCLKT_[x]   | I | Global clock input pin, T(True), [x]:global clock number. |  |  |  |  |
+| GCLKC_[x]  | I | Differential comparsion input pin of GCLKC_[x], C(Comp), [x]: global clock number1. |  |  |  |  |
+| LPLL_T_fb/RPLL_T_fb | I | L/R PLL feedback the input pins, T(True)   |  |  |  |  |
+| LPLL_C_fb/RPLL_C_fb | I | L/R PLL feedback the input pins, C(Comp) |  |  |  |  |
+| LPLL_T_in/RPLL_T_in | I | L/R PLL clock input pins,T(True)  |  |  |  |  |
+| LPLL_C_in/RPLL_C_in | I | L/R PLL clock input pins, C(Comp) |  |  |  |  |
+| CH[7:0] | I | Eight-channel analog input |  |  |  |  |
+| MODE2 | I,Internal Weak Pull Up | GowinCONFIG modes selection pin; if this pin is not bonded, it's internal grounded. |  |  |  |  |
+| MODE1 | I,Internal Weak Pull Up | GowinCONFIG modes selection pin; if this pin is not bonded, it's internal grounded. |  |  |  |  |
+| MODE0 | I,Internal Weak Pull Up | GowinCONFIG modes selection pin; if this pin is not bonded, it's internal grounded. |  |  |  |  |
+| Other Pins |  |  |  |  |  |  |
+| NC | NA | Reserved. |  |  |  |  |
+| VSS | NA | Ground. |  |  |  |  |
+| VCC | NA | Power supply pins for the internal core logic. |  |  |  |  |
+| VCCO# | NA | Power supply pins for I/O voltage of I/O BANK#. |  |  |  |  |
+| VCCX | NA | Power supply pins for auxiliary voltage. |  |  |  |  |
+| VCCP | NA | Power supply pins for FLASH (1.8V). |  |  |  |  |
+| VCCPLL | NA | Power supply pins for PLL. |  |  |  |  |
+| VDDA | NA | ADC Analog power supply voltage, VDDA=3.3V  |  |  |  |  |
+| X16 | NA | I/O supports 16:1. |  |  |  |  |
+| VREF | NA | The input pin of ADC external reference voltage. |  |  |  |  |
+| Note!<br>[1]For single-ended input, the pin of GLKC_[x] is not a global clock pin. |  |  |  |  |  |  |
+
+# Bank
+
+|  |  | IO Bank0 |  |  |  |  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  | IO Bank3 | GW1NSR |  |  |  |  |  |  | IO Bank1 |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  | IO Bank2 |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  | Note！ |  |  |  |  |  |  |  |  |  |
+|  | 1.Each Bank has independent reference volatge (VREF); |  |  |  |  |  |  |  |  |  |
+|  | 2.Users can select to use internal VREF of IOB (equals to 0.5*VCCO) or <br>   external VREF input (use any IO pins as external VREF input). |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+
+# Pin List
+
+| Note!
+1. In packages of QN48P and QN48, IOT7A and IOT7B share pin 10.
+2.HyperRAM is embedded in QN48P; PSRAM is embedded in MG64P; FLASH is embedded in QN48G. |  |  |  |  |  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Pin Name | Function | BANK | Configuration Function | Differential Pair | LVDS | X16 | QN48P | QN48G | MG64P |
+| IOB13A | I/O | 3 |  | True_of_IOB13B | NONE | NONE | 18 | 18 |  |
+| IOB13B | I/O | 3 |  | Comp_of_IOB13A | NONE | NONE | 19 | 19 |  |
+| IOB14A | I/O | 3 |  | True_of_IOB14B | NONE | NONE |  |  |  |
+| IOB14B | I/O | 3 |  | Comp_of_IOB14A | NONE | NONE |  |  |  |
+| IOB15A | I/O | 3 |  | True_of_IOB15B | NONE | NONE |  |  |  |
+| IOB15B | I/O | 3 |  | Comp_of_IOB15A | NONE | NONE |  |  |  |
+| IOB16A/GCLKT_5 | I/O | 3 | GCLKT_5 | True_of_IOB16B | NONE | NONE | 20 | 20 |  |
+| IOB16B/GCLKC_5 | I/O | 3 | GCLKC_5 | Comp_of_IOB16A | NONE | NONE | 21 | 21 |  |
+| IOB22A/GCLKT_4 | I/O | 3 | GCLKT_4 | True_of_IOB22B | NONE | NONE | 22 | 22 |  |
+| IOB22B/GCLKC_4 | I/O | 3 | GCLKC_4 | Comp_of_IOB22A | NONE | NONE | 23 | 23 |  |
+| IOB23A | I/O | 3 |  | True_of_IOB23B | NONE | NONE |  |  |  |
+| IOB23B | I/O | 3 |  | Comp_of_IOB23A | NONE | NONE |  |  |  |
+| IOB24A | I/O | 3 |  | True_of_IOB24B | NONE | NONE |  |  |  |
+| IOB24B | I/O | 3 |  | Comp_of_IOB24A | NONE | NONE |  |  |  |
+| IOB25A | I/O | 3 |  | True_of_IOB25B | NONE | NONE |  |  |  |
+| IOB25B | I/O | 3 |  | Comp_of_IOB25A | NONE | NONE |  |  |  |
+| IOB29A | I/O | 3 |  | True_of_IOB29B | NONE | NONE |  |  |  |
+| IOB29B | I/O | 3 |  | Comp_of_IOB29A | NONE | NONE |  |  |  |
+| IOB4A | I/O | 3 |  | True_of_IOB4B | NONE | NONE | 13 | 13 |  |
+| IOB4B | I/O | 3 |  | Comp_of_IOB4A | NONE | NONE | 14 | 14 |  |
+| IOB5A | I/O | 3 |  | True_of_IOB5B | NONE | NONE | 15 | 15 |  |
+| IOB5B | I/O | 3 |  | Comp_of_IOB5A | NONE | NONE |  |  |  |
+| IOB6A | I/O | 3 |  | True_of_IOB6B | NONE | NONE | 16 | 16 |  |
+| IOB6B | I/O | 3 |  | Comp_of_IOB6A | NONE | NONE | 17 | 17 |  |
+| IOB7A | I/O | 3 |  | True_of_IOB7B | NONE | NONE |  |  |  |
+| IOB7B | I/O | 3 |  | Comp_of_IOB7A | NONE | NONE |  |  |  |
+| IOR11A/GCLKT_3 | I/O | 2 | GCLKT_3 | True_of_IOR11B | True | x16 | 32 | 32 | G5 |
+| IOR11B/GCLKC_3 | I/O | 2 | GCLKC_3 | Comp_of_IOR11A | True | NONE | 31 | 31 | H5 |
+| IOR12A | I/O | 2 |  | True_of_IOR12B | NONE | NONE |  |  |  |
+| IOR12B | I/O | 2 |  | Comp_of_IOR12A | NONE | NONE |  |  |  |
+| IOR13A | I/O | 2 |  | True_of_IOR13B | True | x16 |  |  | G6 |
+| IOR13B | I/O | 2 |  | Comp_of_IOR13A | True | NONE |  |  | H6 |
+| IOR14A | I/O | 2 |  | True_of_IOR14B | NONE | NONE |  |  |  |
+| IOR14B | I/O | 2 |  | Comp_of_IOR14A | NONE | NONE |  |  |  |
+| IOR15A | I/O | 2 |  | True_of_IOR15B | True | x16 | 30 | 30 | G7 |
+| IOR15B | I/O | 2 |  | Comp_of_IOR15A | True | NONE | 29 | 29 | H7 |
+| IOR16A | I/O | 2 |  | True_of_IOR16B | NONE | NONE |  |  |  |
+| IOR16B | I/O | 2 |  | Comp_of_IOR16A | NONE | NONE |  |  |  |
+| IOR17A | I/O | 2 |  | True_of_IOR17B | True | x16 | 28 | 28 | G8 |
+| IOR17B | I/O | 2 |  | Comp_of_IOR17A | True | NONE | 27 | 27 | H8 |
+| IOR18A | I/O | 2 |  | True_of_IOR18B | NONE | NONE |  |  |  |
+| IOR18B | I/O | 2 |  | Comp_of_IOR18A | NONE | NONE |  |  |  |
+| IOR2A/RPLL_T_in | I/O | 2 | RPLL_T_in | True_of_IOR2B | True | x16 | 35 | 35 | G1 |
+| IOR2B/RPLL_C_in | I/O | 2 | RPLL_C_in | Comp_of_IOR2A | True | NONE | 34 | 34 | H1 |
+| IOR3A/RPLL_T_fb | I/O | 2 | RPLL_T_fb | True_of_IOR3B | NONE | NONE |  |  |  |
+| IOR3B/RPLL_C_fb | I/O | 2 | RPLL_C_fb | Comp_of_IOR3A | NONE | NONE |  |  |  |
+| IOR4A | I/O | 2 |  | True_of_IOR4B | True | x16 |  |  | G2 |
+| IOR4B | I/O | 2 |  | Comp_of_IOR4A | True | NONE |  |  | H2 |
+| IOR5A | I/O | 2 |  | True_of_IOR5B | NONE | NONE |  |  |  |
+| IOR5B | I/O | 2 |  | Comp_of_IOR5A | NONE | NONE |  |  |  |
+| IOR6A | I/O | 2 |  | True_of_IOR6B | True | x16 |  |  | G3 |
+| IOR6B | I/O | 2 |  | Comp_of_IOR6A | True | NONE |  |  | H3 |
+| IOR7A | I/O | 2 |  | True_of_IOR7B | NONE | NONE |  |  |  |
+| IOR7B | I/O | 2 |  | Comp_of_IOR7A | NONE | NONE |  |  |  |
+| IOR8A | I/O | 2 |  | True_of_IOR8B | True | x16 |  |  | G4 |
+| IOR8B | I/O | 2 |  | Comp_of_IOR8A | True | NONE |  |  | H4 |
+| IOR9A/GCLKT_2 | I/O | 2 | GCLKT_2 | True_of_IOR9B | NONE | NONE |  |  | F5 |
+| IOR9B/GCLKC_2 | I/O | 2 | GCLKC_2 | Comp_of_IOR9A | NONE | NONE | 33 | 33 | F4 |
+| IOT10A/MCLK/D4 | I/O | 0 | MCLK/D4 | True_of_IOT10B | NONE | NONE | 1 |  |  |
+| IOT10B/MCS_N/D5 | I/O | 0 | MCS_N/D5 | Comp_of_IOT10A | NONE | NONE | 2 |  |  |
+| IOT11A/MO/D6 | I/O | 1 | MO/D6 | True_of_IOT11B | NONE | x16 | 48 |  | A1 |
+| IOT11B/MI/D7 | I/O | 1 | MI/D7 | Comp_of_IOT11A | NONE | NONE | 47 |  | B1 |
+| IOT12A/DIN/CLKHOLD_N | I/O | 1 | DIN/CLKHOLD_N | True_of_IOT12B | NONE | NONE |  | 48 | A2 |
+| IOT12B/DOUT/WE_N | I/O | 1 | DOUT/WE_N | Comp_of_IOT12A | NONE | NONE |  | 47 | B2 |
+| IOT13A/LPLL_T_in | I/O | 1 | LPLL_T_in | True_of_IOT13B | NONE | x16 | 45 | 45 | B3 |
+| IOT13B/LPLL_C_in | I/O | 1 | LPLL_C_in | Comp_of_IOT13A | NONE | NONE | 46 | 46 | A3 |
+| IOT15A/LPLL_T_fb | I/O | 1 | LPLL_T_fb | True_of_IOT15B | NONE | x16 |  |  | B4 |
+| IOT15B/LPLL_C_fb | I/O | 1 | LPLL_C_fb | Comp_of_IOT15A | NONE | NONE |  |  | A4 |
+| IOT17A/GCLKT_0 | I/O | 1 | GCLKT_0 | True_of_IOT17B | NONE | x16 | 43 | 43 | B5 |
+| IOT17B/GCLKC_0 | I/O | 1 | GCLKC_0 | Comp_of_IOT17A | NONE | NONE | 44 | 44 | A5 |
+| IOT20A/GCLKT_1 | I/O | 1 | GCLKT_1 | True_of_IOT20B | NONE | x16 | 41 | 41 | C5 |
+| IOT20B/GCLKC_1 | I/O | 1 | GCLKC_1 | Comp_of_IOT20A | NONE | NONE | 42 | 42 | C4 |
+| IOT21A | I/O | 1 |  | True_of_IOT21B | NONE | NONE |  |  | B6 |
+| IOT21B | I/O | 1 |  | Comp_of_IOT21A | NONE | NONE |  |  | A6 |
+| IOT22A | I/O | 1 |  | True_of_IOT22B | NONE | x16 |  |  | B7 |
+| IOT22B | I/O | 1 |  | Comp_of_IOT22A | NONE | NONE |  |  | A7 |
+| IOT24A | I/O | 1 |  | True_of_IOT24B | NONE | x16 |  |  | A8 |
+| IOT24B | I/O | 1 |  | Comp_of_IOT24A | NONE | NONE |  |  | B8 |
+| IOT26A | I/O | 1 |  | True_of_IOT26B | NONE | x16 | 39 | 39 | C7 |
+| IOT26B | I/O | 1 |  | Comp_of_IOT26A | NONE | NONE | 40 | 40 | C8 |
+| IOT29A | I/O | 1 |  | True_of_IOT29B | NONE | x16 |  |  | E6 |
+| IOT29B | I/O | 1 |  | Comp_of_IOT29A | NONE | NONE |  |  | D6 |
+| IOT2A/TDI | I/O | 0 | TDI | True_of_IOT2B | NONE | x16 | 3 | 3 | E2 |
+| IOT2B/TDO | I/O | 0 | TDO | Comp_of_IOT2A | NONE | NONE | 4 | 4 | E3 |
+| IOT30A | I/O | 1 |  | True_of_IOT30B | NONE | NONE |  |  |  |
+| IOT30B | I/O | 1 |  | Comp_of_IOT30A | NONE | NONE |  |  |  |
+| IOT31A | I/O | 1 |  | True_of_IOT31B | NONE | x16 |  |  | D7 |
+| IOT31B | I/O | 1 |  | Comp_of_IOT31A | NONE | NONE |  |  | D8 |
+| IOT33A | I/O | 1 |  | True_of_IOT33B | NONE | x16 |  |  | E7 |
+| IOT33B | I/O | 1 |  | Comp_of_IOT33A | NONE | NONE |  |  | E8 |
+| IOT35A | I/O | 1 |  | True_of_IOT35B | NONE | x16 |  |  | F7 |
+| IOT35B | I/O | 1 |  | Comp_of_IOT35A | NONE | NONE |  |  | F8 |
+| IOT3A/TMS | I/O | 0 | TMS | True_of_IOT3B | NONE | NONE | 6 | 6 | D2 |
+| IOT3B/TCK | I/O | 0 | TCK | Comp_of_IOT3A | NONE | NONE | 7 | 7 | D3 |
+| IOT4A/SCLK | I/O | 0 | SCLK | True_of_IOT4B | NONE | x16 |  |  | F1 |
+| IOT4B/JTAGSEL_N | I/O | 0 | JTAGSEL_N | Comp_of_IOT4A | NONE | NONE | 8 | 8 | F2 |
+| IOT5A/READY | I/O | 0 | READY | True_of_IOT5B | NONE | NONE |  |  | D1 |
+| IOT5B/DONE | I/O | 0 | DONE | Comp_of_IOT5A | NONE | NONE | 9 | 9 |  |
+| IOT6A/RECONFIG_N | I/O | 0 | RECONFIG_N | True_of_IOT6B | NONE | x16 |  |  | E1 |
+| IOT6B/MODE0 | I/O | 0 | MODE0 | Comp_of_IOT6A | NONE | NONE |  |  |  |
+| IOT7A/MODE1 | I/O | 0 | MODE1 | True_of_IOT7B | NONE | NONE | 10 | 10 |  |
+| IOT7B/MODE2 | I/O | 0 | MODE2 | Comp_of_IOT7A | NONE | NONE | 10 | 10 |  |
+| IOT8A/SSPI_CS_N/D0 | I/O | 0 | SSPI_CS_N/D0 | True_of_IOT8B | NONE | x16 |  |  | C1 |
+| IOT8B/SO/D1 | I/O | 0 | SO/D1 | Comp_of_IOT8A | NONE | NONE |  |  | C2 |
+| IOT9A/SI/D2 | I/O | 0 | SI/D2 | True_of_IOT9B | NONE | NONE |  | 1 |  |
+| IOT9B/FASTRD_N/D3 | I/O | 0 | FASTRD_N/D3 | Comp_of_IOT9A | NONE | NONE |  | 2 |  |
+| VCC | Power | N/A |  |  |  |  | 11 | 11 | D5 |
+| VCC | Power | N/A |  |  |  |  | 37 | 37 |  |
+| VCCO0 | Power | N/A |  |  |  |  | 5 | 5 | C3 |
+| VCCO1 | Power | N/A |  |  |  |  | 38 | 38 | C6 |
+| VCCO2 | Power | N/A |  |  |  |  |  |  | F6 |
+| VCCO2 | Power | N/A |  |  |  |  | 36 | 36 |  |
+| VCCO3 | Power | N/A |  |  |  |  | 12 | 12 | F3 |
+| VCCO3 | Power | N/A |  |  |  |  | 24 | 24 |  |
+| VCCX | Power | N/A |  |  |  |  | 25 | 25 | E4 |
+| VSS | Ground | N/A |  |  |  |  |  |  | D4 |
+| VSS | Ground | N/A |  |  |  |  |  |  | E5 |
+| VSS | Ground | N/A |  |  |  |  | 26 | 26 |  |
+
+# True LVDS
+
+| Pin Name | Function | BANK | Configuration Function | Differential Pair | LVDS | X16 | QN48P | QN48G | MG64P |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| BANK2 True LVDS Pair |  |  |  |  |  |  |  |  |  |
+| IOR11A/GCLKT_3 | I/O | 2 | GCLKT_3 | True_of_IOR11B | True | x16 | 32 | 32 | G5 |
+| IOR11B/GCLKC_3 | I/O | 2 | GCLKC_3 | Comp_of_IOR11A | True | NONE | 31 | 31 | H5 |
+| IOR13A | I/O | 2 |  | True_of_IOR13B | True | x16 |  |  | G6 |
+| IOR13B | I/O | 2 |  | Comp_of_IOR13A | True | NONE |  |  | H6 |
+| IOR15A | I/O | 2 |  | True_of_IOR15B | True | x16 | 30 | 30 | G7 |
+| IOR15B | I/O | 2 |  | Comp_of_IOR15A | True | NONE | 29 | 29 | H7 |
+| IOR17A | I/O | 2 |  | True_of_IOR17B | True | x16 | 28 | 28 | G8 |
+| IOR17B | I/O | 2 |  | Comp_of_IOR17A | True | NONE | 27 | 27 | H8 |
+| IOR2A/RPLL_T_in | I/O | 2 | RPLL_T_in | True_of_IOR2B | True | x16 | 35 | 35 | G1 |
+| IOR2B/RPLL_C_in | I/O | 2 | RPLL_C_in | Comp_of_IOR2A | True | NONE | 34 | 34 | H1 |
+| IOR4A | I/O | 2 |  | True_of_IOR4B | True | x16 |  |  | G2 |
+| IOR4B | I/O | 2 |  | Comp_of_IOR4A | True | NONE |  |  | H2 |
+| IOR6A | I/O | 2 |  | True_of_IOR6B | True | x16 |  |  | G3 |
+| IOR6B | I/O | 2 |  | Comp_of_IOR6A | True | NONE |  |  | H3 |
+| IOR8A | I/O | 2 |  | True_of_IOR8B | True | x16 |  |  | G4 |
+| IOR8B | I/O | 2 |  | Comp_of_IOR8A | True | NONE |  |  | H4 |
+
+# Power
+
+| Note!
+It is recommended to connect  VCCX with the VCCO with the maximum voltage. |  |  |  |  |  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Recommended Operating Conditions for GW1NSR-4C QN48P Packages |  |  |  |  |  |  |  |  |  |
+| Name | Description |  |  |  | Min. | Max. |  |  |  |
+| VCC | Core volatge |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCO0, VCCO1, <br>VCCO2, VCCO3 | I/O Bank volatge |  |  |  | 1.14V | 3.465V |  |  |  |
+|  | When HyperRAM is employed, VCCO3 provides power to HyperRAM. |  |  |  | 1.71V | 1.89V |  |  |  |
+|  | When MIPI input of BANK0 and BANK1 is employed, VCCO0 and VCCO1 needs to be supplied with 1.2V. |  |  |  | 1.14V | 1.26V |  |  |  |
+|  | VCCO2 needs to be supplied with 1.2V when BANK2 MIPI output is employed. |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCX | Auxiliary voltage |  |  |  | 1.71V | 3.465V |  |  |  |
+| Recommended Operating Conditions for GW1NSR-4C QN48G |  |  |  |  |  |  |  |  |  |
+| Name | Description |  |  |  | Min. | Max. |  |  |  |
+| VCC | Core volatge |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCO0, VCCO1, <br>VCCO2, VCCO3 | I/O Bank volatge |  |  |  | 1.14V | 3.465V |  |  |  |
+|  | When FLASH is employed, VCCO0 and VCCO1 provide power to FLASH. |  |  |  | 2.565V | 3.465V |  |  |  |
+|  | When MIPI input of BANK0 and BANK1 is employed, VCCO0 and VCCO1 needs to be supplied with 1.2V. |  |  |  | 1.14V | 1.26V |  |  |  |
+|  | VCCO2 needs to be supplied with 1.2V when BANK2 MIPI output is employed. |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCX | Auxiliary voltage |  |  |  | 1.71V | 3.465V |  |  |  |
+| Recommended Operating Conditions for GW1NSR-4C MG64P |  |  |  |  |  |  |  |  |  |
+| Name | Description |  |  |  | Min. | Max. |  |  |  |
+| VCC | Core volatge |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCO0, VCCO1, <br>VCCO2, VCCO3 | I/O Bank volatge |  |  |  | 1.14V | 3.465V |  |  |  |
+|  | When PSRAM is employed, VCCO3 provides power to PSRAM. |  |  |  | 1.71V | 1.89V |  |  |  |
+|  | When MIPI input of BANK0 and BANK1 is employed, VCCO0 and VCCO1 needs to be supplied with 1.2V. |  |  |  | 1.14V | 1.26V |  |  |  |
+|  | VCCO2 needs to be supplied with 1.2V when BANK2 MIPI output is employed. |  |  |  | 1.14V | 1.26V |  |  |  |
+| VCCX | Auxiliary voltage |  |  |  | 1.71V | 3.465V |  |  |  |


### PR DESCRIPTION
Converted all hardware definition files (PDFs, XLSX, and PNG reference) in the `definitions/` directory to Markdown format as per the project requirements. Used `pdftotext` for PDFs and a custom Python script with `openpyxl` for the Excel pinout file. renamed files to use snake_case for better compatibility.

Fixes #35

---
*PR created automatically by Jules for task [11686386486540669862](https://jules.google.com/task/11686386486540669862) started by @chatelao*