### PR TITLE
Implement software PWM support for Tang Nano 4K

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Next steps for the MicroPython for Tang Nano 4K project:
 - [x] 10. Implement GitHub Actions for build and release CI/CD.
 - [x] 11. Implement basic GPIO and LED control (Machine.Pin class).
 - [x] 12. Implement timer and delay using Cortex-M3 SysTick (Machine.Timer class).
-- [ ] 13. Implement PWM support (Machine.PWM class).
+- [x] 13. Implement PWM support (Machine.PWM class).
 
 ## Past Steps
 - [x] 1. Initialize project structure and documentation.

--- a/src/ports/tang_nano_4k/Makefile
+++ b/src/ports/tang_nano_4k/Makefile
@@ -49,6 +49,7 @@ SRC_C = \
 	uart.c \
 	pin.c \
 	timer.c \
+	pwm.c \
 	modmachine.c \
 	$(TOP)/shared/libc/printf.c \
 	$(TOP)/shared/runtime/stdout_helpers.c \

--- a/src/ports/tang_nano_4k/main.c
+++ b/src/ports/tang_nano_4k/main.c
@@ -13,6 +13,7 @@
 #include "shared/runtime/pyexec.h"
 #include "mphalport.h"
 #include "timer.h"
+#include "pwm.h"
 
 // Heap for MicroPython
 static char heap[16 * 1024];
@@ -42,6 +43,12 @@ extern volatile mp_uint_t ticks_ms;
 void SysTick_Handler(void) {
     ticks_ms++;
     machine_timer_tick_all();
+}
+
+#define TIMER1_INTCLEAR (*(volatile uint32_t *)(0x4000100C))
+void TIMER1_Handler(void) {
+    TIMER1_INTCLEAR = 1;
+    machine_pwm_tick();
 }
 
 void gc_collect(void) {
@@ -97,5 +104,15 @@ const uint32_t isr_vector[] __attribute__((section(".isr_vector"))) = {
     (uint32_t)&_estack,
     (uint32_t)&Reset_Handler,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    (uint32_t)&SysTick_Handler,
+    (uint32_t)&SysTick_Handler,     // 0x3C
+    0, // UART0_Handler             // 0x40
+    0, // USER_INT0_Handler
+    0, // UART1_Handler
+    0, // USER_INT1_Handler
+    0, // USER_INT2_Handler
+    0, // Reserved
+    0, // PORT0_COMB_Handler
+    0, // USER_INT3_Handler
+    0, // TIMER0_Handler            // 0x60
+    (uint32_t)&TIMER1_Handler,      // 0x64
 };

--- a/src/ports/tang_nano_4k/modmachine.c
+++ b/src/ports/tang_nano_4k/modmachine.c
@@ -1,11 +1,13 @@
 #include "py/runtime.h"
 #include "pin.h"
 #include "timer.h"
+#include "pwm.h"
 
 static const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_machine) },
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_Timer), MP_ROM_PTR(&machine_timer_type) },
+    { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&machine_pwm_type) },
 };
 static MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 

--- a/src/ports/tang_nano_4k/pwm.c
+++ b/src/ports/tang_nano_4k/pwm.c
@@ -1,0 +1,202 @@
+#include <stdint.h>
+#include "py/runtime.h"
+#include "py/mperrno.h"
+#include "py/mphal.h"
+#include "pin.h"
+#include "pwm.h"
+
+#define TIMER1_BASE 0x40001000
+#define TIMER1_CTRL (*(volatile uint32_t *)(TIMER1_BASE + 0x00))
+#define TIMER1_RELOAD (*(volatile uint32_t *)(TIMER1_BASE + 0x08))
+#define TIMER1_INTCLEAR (*(volatile uint32_t *)(TIMER1_BASE + 0x0C))
+
+#define GPIO_BASE (0x40010000)
+#define REG_DATAOUT (*(volatile uint32_t *)(GPIO_BASE + 0x0004))
+#define REG_OUTENSET (*(volatile uint32_t *)(GPIO_BASE + 0x0010))
+#define REG_ALTFUNCCLR (*(volatile uint32_t *)(GPIO_BASE + 0x001C))
+
+#define NVIC_ISER0 (*(volatile uint32_t *)(0xE000E100))
+
+#define MAX_PWM 8
+MP_REGISTER_ROOT_POINTER(struct _machine_pwm_obj_t *active_pwm[8]);
+
+#define PWM_RESOLUTION 100
+
+typedef struct _machine_pwm_obj_t {
+    mp_obj_base_t base;
+    uint32_t pin_id;
+    uint32_t freq;
+    uint32_t duty;
+    uint32_t threshold;
+    bool active;
+} machine_pwm_obj_t;
+
+static uint32_t pwm_tick_counter = 0;
+
+static void update_timer_freq(uint32_t freq) {
+    if (freq == 0) return;
+    // Timer frequency = CPU_FREQ / (RELOAD + 1)
+    // We want PWM frequency * PWM_RESOLUTION
+    uint32_t reload = (CPU_FREQ / (freq * PWM_RESOLUTION)) - 1;
+    TIMER1_RELOAD = reload;
+}
+
+void machine_pwm_tick(void) {
+    pwm_tick_counter++;
+    if (pwm_tick_counter >= PWM_RESOLUTION) {
+        pwm_tick_counter = 0;
+    }
+
+    for (int i = 0; i < MAX_PWM; i++) {
+        machine_pwm_obj_t *pwm = MP_STATE_PORT(active_pwm)[i];
+        if (pwm && pwm->active) {
+            if (pwm_tick_counter < pwm->threshold) {
+                REG_DATAOUT |= (1 << pwm->pin_id);
+            } else {
+                REG_DATAOUT &= ~(1 << pwm->pin_id);
+            }
+        }
+    }
+}
+
+static void machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "PWM(pin=%u, freq=%u, duty=%u)",
+        (unsigned int)self->pin_id, (unsigned int)self->freq, (unsigned int)self->duty);
+}
+
+static mp_obj_t machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+
+    // Pin should be passed as the first argument
+    uint32_t pin_id;
+    if (mp_obj_is_type(args[0], &machine_pin_type)) {
+        machine_pin_obj_t *pin = MP_OBJ_TO_PTR(args[0]);
+        pin_id = pin->pin_id;
+    } else {
+        pin_id = mp_obj_get_int(args[0]);
+    }
+
+    if (pin_id >= 16) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
+    }
+
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
+    self->base.type = &machine_pwm_type;
+    self->pin_id = pin_id;
+    self->freq = 1000;
+    self->duty = 512;
+    self->threshold = (self->duty * PWM_RESOLUTION) / 1024;
+    self->active = false;
+
+    // Set pin to output and clear alt func
+    REG_OUTENSET = (1 << self->pin_id);
+    REG_ALTFUNCCLR = (1 << self->pin_id);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static mp_obj_t machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_freq, ARG_duty };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_freq, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_duty, MP_ARG_INT, {.u_int = -1} },
+    };
+
+    mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
+
+    if (vals[ARG_freq].u_int != -1) {
+        self->freq = vals[ARG_freq].u_int;
+    }
+    if (vals[ARG_duty].u_int != -1) {
+        self->duty = vals[ARG_duty].u_int;
+        // duty is 0-1023 in some older MP, or duty_u16 0-65535.
+        // Let's assume 0-1023 for now or scale if needed.
+        // Actually MicroPython PWM duty is 0-1023.
+        self->threshold = (self->duty * PWM_RESOLUTION) / 1024;
+    }
+
+    // Find a slot in active_pwm
+    int slot = -1;
+    for (int i = 0; i < MAX_PWM; i++) {
+        if (MP_STATE_PORT(active_pwm)[i] == self) {
+            slot = i;
+            break;
+        }
+        if (slot == -1 && MP_STATE_PORT(active_pwm)[i] == NULL) {
+            slot = i;
+        }
+    }
+
+    if (slot != -1) {
+        MP_STATE_PORT(active_pwm)[slot] = self;
+        self->active = true;
+    }
+
+    // Start timer if not already running
+    update_timer_freq(self->freq);
+    TIMER1_CTRL = 0x09; // Enable, Interrupt Enable
+    NVIC_ISER0 |= (1 << 9); // Enable IRQ 9 (TIMER1)
+
+    return mp_const_none;
+}
+
+static mp_obj_t machine_pwm_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    return machine_pwm_init_helper(MP_OBJ_TO_PTR(args[0]), n_args - 1, args + 1, kw_args);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(machine_pwm_init_obj, 1, machine_pwm_init);
+
+static mp_obj_t machine_pwm_deinit(mp_obj_t self_in) {
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->active = false;
+    for (int i = 0; i < MAX_PWM; i++) {
+        if (MP_STATE_PORT(active_pwm)[i] == self) {
+            MP_STATE_PORT(active_pwm)[i] = NULL;
+            break;
+        }
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pwm_deinit_obj, machine_pwm_deinit);
+
+static mp_obj_t machine_pwm_freq(size_t n_args, const mp_obj_t *args) {
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        return MP_OBJ_NEW_SMALL_INT(self->freq);
+    } else {
+        self->freq = mp_obj_get_int(args[1]);
+        update_timer_freq(self->freq);
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pwm_freq_obj, 1, 2, machine_pwm_freq);
+
+static mp_obj_t machine_pwm_duty(size_t n_args, const mp_obj_t *args) {
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        return MP_OBJ_NEW_SMALL_INT(self->duty);
+    } else {
+        self->duty = mp_obj_get_int(args[1]);
+        self->threshold = (self->duty * PWM_RESOLUTION) / 1024;
+        return mp_const_none;
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pwm_duty_obj, 1, 2, machine_pwm_duty);
+
+static const mp_rom_map_elem_t machine_pwm_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_pwm_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_pwm_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_freq), MP_ROM_PTR(&machine_pwm_freq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_duty), MP_ROM_PTR(&machine_pwm_duty_obj) },
+};
+static MP_DEFINE_CONST_DICT(machine_pwm_locals_dict, machine_pwm_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_pwm_type,
+    MP_QSTR_PWM,
+    MP_TYPE_FLAG_NONE,
+    make_new, machine_pwm_make_new,
+    print, machine_pwm_print,
+    locals_dict, &machine_pwm_locals_dict
+);

--- a/src/ports/tang_nano_4k/pwm.h
+++ b/src/ports/tang_nano_4k/pwm.h
@@ -1,0 +1,10 @@
+#ifndef MICROPY_INCLUDED_TANG_NANO_4K_PWM_H
+#define MICROPY_INCLUDED_TANG_NANO_4K_PWM_H
+
+#include "py/obj.h"
+
+extern const mp_obj_type_t machine_pwm_type;
+
+void machine_pwm_tick(void);
+
+#endif // MICROPY_INCLUDED_TANG_NANO_4K_PWM_H

--- a/test/verify_pwm.robot
+++ b/test/verify_pwm.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Suite Setup     Setup
+Suite Teardown  Teardown
+Test Setup      Reset Emulation
+Resource        ${RENODEKEYWORDS}
+
+*** Variables ***
+${RESC}         ${CURDIR}/test/tang_nano_4k.resc
+${REPL}         ${CURDIR}/test/tang_nano_4k.repl
+${BIN}          ${CURDIR}/src/ports/tang_nano_4k/build/firmware.elf
+${UART}         sysbus.uart0
+
+*** Test Cases ***
+Should Verify PWM Interface
+    Execute Command         $repl = @${REPL}
+    Execute Command         $bin = @${BIN}
+    Execute Command         include @${RESC}
+    Execute Command         sysbus.cpu VectorTableOffset 0x60000000
+    Execute Command         sysbus.cpu SP `sysbus ReadDoubleWord 0x60000000`
+    Execute Command         sysbus.cpu PC `sysbus ReadDoubleWord 0x60000004`
+    Create Terminal Tester  ${UART}
+    Start Emulation
+    Wait For Text On Uart   MicroPython started on Tang Nano 4K
+    Wait For Text On Uart   >>>
+    Write Line To Uart      from machine import PWM, Pin
+    Wait For Text On Uart   >>>
+    Write Line To Uart      pwm = PWM(Pin(0))
+    Wait For Text On Uart   >>>
+    Write Line To Uart      print(pwm)
+    Wait For Text On Uart   PWM(pin=0, freq=1000, duty=512)
+    Write Line To Uart      pwm.freq(2000)
+    Wait For Text On Uart   >>>
+    Write Line To Uart      pwm.duty(256)
+    Wait For Text On Uart   >>>
+    Write Line To Uart      print(pwm)
+    Wait For Text On Uart   PWM(pin=0, freq=2000, duty=256)
+    Write Line To Uart      pwm.deinit()
+    Wait For Text On Uart   >>>

--- a/test_pwm.py
+++ b/test_pwm.py
@@ -1,0 +1,30 @@
+from machine import PWM, Pin
+import time
+
+print("Testing PWM...")
+
+# Initialize PWM on Pin 0
+pwm0 = PWM(Pin(0))
+print("PWM on Pin 0:", pwm0)
+
+# Set frequency
+pwm0.freq(2000)
+print("Frequency set to 2000:", pwm0.freq())
+
+# Set duty cycle
+pwm0.duty(256) # 25% duty cycle
+print("Duty cycle set to 256:", pwm0.duty())
+
+# Re-init with parameters
+pwm0.init(freq=500, duty=512)
+print("PWM after init(freq=500, duty=512):", pwm0)
+
+# Test multiple PWMs
+pwm1 = PWM(1)
+pwm1.init(freq=1000, duty=100)
+print("PWM on Pin 1:", pwm1)
+
+# Deinit
+pwm0.deinit()
+pwm1.deinit()
+print("PWM deinitialized")


### PR DESCRIPTION
This change implements software PWM support for the Tang Nano 4K MicroPython port. Since there is no dedicated hardware PWM peripheral in the Cortex-M3 hard-core, PWM is achieved by toggling GPIO pins in an interrupt handler driven by hardware Timer1. This allows for adjustable frequency and duty cycle across multiple GPIO pins. The implementation follows the standard MicroPython `machine.PWM` API.

Fixes #54

---
*PR created automatically by Jules for task [13522336100670941369](https://jules.google.com/task/13522336100670941369) started by @chatelao*