### PR TITLE
Add Silicon-to-Metal Interconnection Matrix to Documentation

### DIFF
--- a/documentation/CONCEPT_HARDWARE_SPECS.md
+++ b/documentation/CONCEPT_HARDWARE_SPECS.md
@@ -53,3 +53,22 @@ This document outlines the hardware specifications for the Sipeed Tang Nano 4K d
 - [x] Detailed memory map for Cortex-M3.
 - [x] Peripheral register mapping.
 - [x] Implement SoftI2C support.
+
+## Silicon-to-Metal Interconnection Matrix
+
+This matrix defines the interconnection points between the hard-core silicon (Cortex-M3 subsystem) and the metal-programmable FPGA fabric and resources.
+
+| Silicon Area \ Metal Area | Logic Fabric | BSRAM | DSP | PLL | Bank 0 | Bank 1 | Bank 2 | Bank 3 |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Cortex-M3 Core** | X | | | | | | | |
+| **Internal SRAM** | X | | | | | | | |
+| **Internal Flash** | X | | | | | | | |
+| **UART 0 / 1** | X | | | | | | | |
+| **Timer 0 / 1** | X | | | | | | | |
+| **I2C 0 / SPI 0** | X | | | | | | | |
+| **ADC IP** | X | | | | | | | |
+| **GPIO Bridge** | X | | | | | | | |
+| **NVIC (IRQs)** | X | | | | | | | |
+| **SYSCON** | X | | | | | | | |
+
+*Note: 'X' indicates a direct electrical or bus-level interface between the silicon hard-core and the programmable metal/logic fabric. Peripherals in silicon route their I/O signals through the logic fabric to reach physical I/O banks.*


### PR DESCRIPTION
Added the Silicon-to-Metal Interconnection Matrix to the hardware specifications documentation. This matrix illustrates the architectural boundaries and connection points between the 'Silicon' (Cortex-M3 Hard Core and its internal components) and the 'Metal' (FPGA logic fabric and associated programmable resources) on the Gowin GW1NSR-4C SoC used in the Tang Nano 4K.

Fixes #119

---
*PR created automatically by Jules for task [1305097954423006050](https://jules.google.com/task/1305097954423006050) started by @chatelao*