### PR TITLE
document UART configuration for Tang Nano 4K

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,25 @@ This project aims to port MicroPython to the "Sipeed Tang Nano 4K" FPGA developm
 - `/.github` - Workflows for CI/CD.
 - `ROADMAP.md` - Progress tracking and future steps.
 
+## UART Configuration
+The MicroPython REPL is accessible via the Cortex-M3 UART0 peripheral.
+
+### Hardware Wiring
+The UART0 signals are routed through the FPGA fabric to the following pins:
+- **UART0 RX**: FPGA Pin 34 (IOR2B)
+- **UART0 TX**: FPGA Pin 35 (IOR2A)
+
+To access the REPL via the onboard USB-C connector (BL702 bridge), the following solder bridges must be populated on the bottom of the PCB:
+- **R11**: Connects BL702 RX to FPGA Pin 35 (TX).
+- **R12**: Connects BL702 TX to FPGA Pin 34 (RX).
+
+### Terminal Settings
+Use a serial terminal with the following configuration:
+- **Baud Rate**: 115200
+- **Data Bits**: 8
+- **Parity**: None
+- **Stop Bits**: 1
+- **Flow Control**: None (8N1)
+
 ## Progress
 Update `ROADMAP.md` for the current status and upcoming tasks.


### PR DESCRIPTION
Added a "UART Configuration" section to the README.md. This section describes the hardware wiring of the Cortex-M3 UART0 to FPGA pins 34 (RX) and 35 (TX), the required hardware modifications (solder bridges R11 and R12) for USB-UART access, and the default terminal settings (115200 8N1).

Fixes #128

---
*PR created automatically by Jules for task [7558831351560620851](https://jules.google.com/task/7558831351560620851) started by @chatelao*