### PR TITLE
Update UART0 Routing to Pins 18 and 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ The MicroPython REPL is accessible via the Cortex-M3 UART0 peripheral.
 
 ### Hardware Wiring
 The UART0 signals are routed through the FPGA fabric to the following pins:
-- **UART0 RX**: FPGA Pin 34 (IOR2B)
-- **UART0 TX**: FPGA Pin 35 (IOR2A)
+- **UART0 RX**: FPGA Pin 19 (IOB13B)
+- **UART0 TX**: FPGA Pin 18 (IOB13A)
 
-To access the REPL via the onboard USB-C connector (BL702 bridge), the following solder bridges must be populated on the bottom of the PCB:
-- **R11**: Connects BL702 RX to FPGA Pin 35 (TX).
-- **R12**: Connects BL702 TX to FPGA Pin 34 (RX).
+To access the REPL via the onboard USB-C connector (BL702 bridge), the following solder bridges must be populated on the bottom of the PCB (Note: This configuration routes UART0 to pins 34 and 35, and is incompatible with the default routing to pins 18 and 19):
+- **R11**: Connects BL702 RX to FPGA Pin 35.
+- **R12**: Connects BL702 TX to FPGA Pin 34.
 
 ### Terminal Settings
 Use a serial terminal with the following configuration:

--- a/documentation/CONCEPT_HARDWARE_SPECS.md
+++ b/documentation/CONCEPT_HARDWARE_SPECS.md
@@ -47,6 +47,12 @@ This document outlines the hardware specifications for the Sipeed Tang Nano 4K d
 | INTSTATUS | 0x0C | Interrupt status (R/W) |
 | BAUDDIV | 0x10 | Baudrate divider (R/W) |
 
+#### UART0 Signal Mapping
+| Signal | FPGA Pin | Bank | Function |
+| --- | --- | --- | --- |
+| UART0_TXD | Pin 18 | 3 | IOB13A |
+| UART0_RXD | Pin 19 | 3 | IOB13B |
+
 ## Implementation Status
 - [x] Research target hardware specifications.
 - [x] Document basic specifications.

--- a/documentation/SERIAL_PORT_ACCESS.md
+++ b/documentation/SERIAL_PORT_ACCESS.md
@@ -8,16 +8,20 @@ The Tang Nano 4K features a GW1NSR-LV4C SoC with an integrated ARM Cortex-M3 cor
 
 ## Hardware Modification (Soldering)
 
-To enable serial communication over USB, you must solder two bridges on the **bottom side** of the PCB.
+The current default UART0 routing uses **FPGA Pin 18 (TX)** and **FPGA Pin 19 (RX)**, which are available on the physical pin headers.
+
+To enable serial communication over the onboard USB-C connector (via the BL702 bridge), legacy routing to pins 34 and 35 is required. This involves soldering two bridges on the **bottom side** of the PCB:
 
 1.  Locate pads **R11** and **R12** near the BL702 chip.
 2.  **R11**: Solder a bridge (0Ω resistor or solder blob) to connect the BL702 RX to FPGA Pin 35.
 3.  **R12**: Solder a bridge (0Ω resistor or solder blob) to connect the BL702 TX to FPGA Pin 34.
 
-| Component | Function | M3 Signal | FPGA Pin |
+| Component | Function | M3 Signal | Legacy FPGA Pin |
 | :--- | :--- | :--- | :--- |
 | **R11** | UART TX | UART0 TX | Pin 35 (IOR2A) |
 | **R12** | UART RX | UART0 RX | Pin 34 (IOR2B) |
+
+**Note**: Using Header Pins 18 and 19 does not require any soldering.
 
 ## Software Configuration
 
@@ -40,4 +44,4 @@ When connecting to the board's serial port on your computer, use the following s
 ## Important Considerations
 
 *   **HDMI Conflict**: Pins 34 and 35 are also used for HDMI signals (`HDMI_TX2`). If your FPGA bitstream uses both HDMI and the Cortex-M3 UART0 on these pins, you may experience interference or failure of one or both interfaces.
-*   **Bitstream Routing**: Ensure your Gowin EDA project correctly routes the `UART0_TXD` and `UART0_RXD` signals of the Cortex-M3 "Hard Core" to pins 35 and 34 respectively in the Floor Planner (CST file).
+*   **Bitstream Routing**: Ensure your Gowin EDA project correctly routes the `UART0_TXD` and `UART0_RXD` signals of the Cortex-M3 "Hard Core" to pins 18 and 19 respectively in the Floor Planner (CST file).

--- a/test/tang_nano_4k.repl
+++ b/test/tang_nano_4k.repl
@@ -15,6 +15,9 @@ sram: Memory.MappedMemory @ sysbus 0x20000000
     size: 0x5800
 
 // CMSDK UART0 - Moved to correct hardware base address
+// Routed via FPGA fabric to physical pins:
+// TX -> FPGA Pin 18 (IOB13A)
+// RX -> FPGA Pin 19 (IOB13B)
 uart0: UART.CMSDK_APB_UART @ sysbus 0x40004000
     frequency: 27000000
 


### PR DESCRIPTION
This submission updates the project's documentation and simulation configuration to change the defined UART0 routing from pins 34/35 to pins 18/19. Since the FPGA bitstream source is not present in the repository, this change aligns the MicroPython port's specifications, simulation environment, and user instructions with the new hardware target. It also adds critical warnings about the hardware implications for the onboard USB-C REPL.

Fixes #131

---
*PR created automatically by Jules for task [6793669574217813359](https://jules.google.com/task/6793669574217813359) started by @chatelao*