### PR TITLE
Verify FSRAM/FastRAM benefits and document RAM usage

### DIFF
--- a/RAM_XX_USAGE.md
+++ b/RAM_XX_USAGE.md
@@ -1,0 +1,56 @@
+# RAM Usage and Potential Expansion - Tang Nano 4K (GW1NSR-4C)
+
+This document analyzes the current memory usage of the MicroPython port and evaluates the feasibility and benefits of utilizing additional memory regions: **FastRAM**, **FSRAM**, and **External PSRAM**.
+
+## 1. Current Memory Architecture
+
+The GW1NSR-4C integrated Cortex-M3 "Hard Core" has a primary internal SRAM space of **22 KB** (mapped at `0x20000000`). This memory is physically implemented using the SoC's Block SRAM (BSRAM) resources.
+
+### Current Allocation:
+- **Stack**: 2 KB (at the top of SRAM: `0x20005800` - `0x20005FFF`)
+- **Data/BSS**: ~1-2 KB (statically allocated)
+- **Heap**: ~18-19 KB (the remaining space for MicroPython objects)
+
+## 2. FastRAM (Tightly Coupled Memory)
+
+**Definition**: In many Cortex-M3 implementations, "FastRAM" refers to Tightly Coupled Memory (ITCM/DTCM) or the zero-wait-state internal SRAM.
+
+### Findings for Tang Nano 4K:
+- The internal **22 KB SRAM** at `0x20000000` *is* the "FastRAM". It is connected via the high-speed AHB-Lite bus and provides optimal performance for the CPU.
+- **Status**: Already fully utilized. There are no additional hidden "FastRAM" pools within the M3 hard core itself.
+
+## 3. FSRAM (Fabric-based SRAM / Shadow RAM)
+
+**Definition**: **FSRAM** (Fabric SRAM) refers to memory implemented using the FPGA logic fabric. This includes **Shadow RAM (SSRAM)**, which utilizes LUTs as small distributed memory blocks.
+
+### Performance and Feasibility:
+- **Capacity**: Utilizing a significant amount of FSRAM (e.g., 8-16 KB) would consume thousands of LUT4 logic units, severely limiting the space available for user FPGA logic (total 4608 LUTs).
+- **Latency**: Accessing FSRAM from the M3 requires passing through the **AHB-to-FPGA Bridge** or **TARGEXP0 slave port**, introducing wait states compared to the internal SRAM.
+- **Helpfulness**: **Low**. Using FSRAM for the main MicroPython heap is inefficient due to the high logic cost and lower performance. It is better reserved for small, specialized buffers or communication mailboxes between the M3 and FPGA.
+
+## 4. External PSRAM (The High-Capacity Solution)
+
+The Tang Nano 4K board includes an integrated **64 Mbit (8 MB) PSRAM** chip connected to the GW1NSR-4C.
+
+### Potential Benefits:
+- **Capacity**: 8 MB is **~360x larger** than the current 22 KB internal SRAM.
+- **Accessibility**: The SoC includes a dedicated **PSRAM Memory Interface** reachable via the **AHB2 Master bus** (base `0xA0000000`).
+
+### Requirements for Integration:
+1. **FPGA Bitstream**: The PSRAM controller IP must be instantiated in the FPGA fabric and routed to the physical PSRAM pins.
+2. **MicroPython Heap**: The MicroPython heap can be moved to the PSRAM region by updating `main.c` and the linker script, though this would incur a performance penalty (latency) compared to internal SRAM.
+
+## 5. Summary and Recommendation
+
+| Region | Capacity | Performance | Helpfulness | Recommendation |
+| :--- | :--- | :--- | :--- | :--- |
+| **FastRAM** (Internal) | 22 KB | Highest | Essential | Already in use. |
+| **FSRAM** (Shadow) | ~1-9 KB | Moderate | Low | Do not use for general heap. |
+| **PSRAM** (External) | 8 MB | Lower | **Highest** | **High Priority** for future heap expansion. |
+
+### Conclusion:
+- **FastRAM (Internal SRAM)**: No further action needed; it is already optimized for the stack and core heap.
+- **FSRAM**: Not recommended for general MicroPython usage due to FPGA resource exhaustion.
+- **PSRAM**: This is the only viable path for significant memory expansion. It would allow for much larger Python scripts, framebuffers, and complex data structures.
+
+**Next Step Recommendation**: Future development should focus on implementing a "PSRAM variant" of the firmware that initializes the PSRAM controller in the FPGA and utilizes the 8 MB region for the MicroPython heap.


### PR DESCRIPTION
I have verified the available RAM regions on the Tang Nano 4K (GW1NSR-4C) and evaluated the potential benefits of using FSRAM (Fabric SRAM/Shadow RAM) and FastRAM (Internal SRAM).

### Key Findings:
- **FastRAM**: Refers to the internal **22 KB SRAM** (0x20000000), which is already fully utilized for the stack and the MicroPython heap.
- **FSRAM**: Refers to **Shadow RAM (SSRAM)** implemented in the FPGA fabric using LUTs. While it can provide up to ~9KB, it is not recommended for general heap expansion due to high logic resource consumption and AHB bridge latency.
- **External PSRAM**: The board includes **8 MB** of PSRAM accessible via the AHB2 Master bus. This is the recommended path for significant memory expansion.

The results and recommendations are documented in the newly created `RAM_XX_USAGE.md` file. I have also ensured that no regressions were introduced and that the repository remains clean of temporary build or test artifacts.

Fixes #173

---
*PR created automatically by Jules for task [9260383147981959313](https://jules.google.com/task/9260383147981959313) started by @chatelao*