### PR TITLE
Implement CI Caching for ARM Toolchain and MicroPython Core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache ARM GNU Toolchain
+        id: cache-toolchain
+        uses: actions/cache@v4
+        with:
+          path: arm-toolchain
+          key: arm-toolchain-${{ runner.os }}-10.3-2021.10
+
       - name: Install ARM GNU Toolchain
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+          wget -q https://developer.arm.com/-/media/files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+          mkdir -p arm-toolchain
+          tar -xj -f gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C arm-toolchain --strip-components=1
+
+      - name: Add ARM Toolchain to PATH
+        run: echo "${{ github.workspace }}/arm-toolchain/bin" >> $GITHUB_PATH
+
+      - name: Cache MicroPython core
+        id: cache-micropython
+        uses: actions/cache@v4
+        with:
+          path: src/lib/micropython
+          key: micropython-v1.24.1-${{ runner.os }}-${{ hashFiles('src/ports/tang_nano_4k/mpconfigport.h') }}
 
       - name: Clone MicroPython core
+        if: steps.cache-micropython.outputs.cache-hit != 'true'
         run: |
           # Use a specific tag for stability (e.g., v1.24.1)
           git clone --depth 1 --branch v1.24.1 https://github.com/micropython/micropython.git src/lib/micropython
 
-      - name: Build mpy-cross
+      - name: Build mpy-cross and Reference Unix Port
+        if: steps.cache-micropython.outputs.cache-hit != 'true'
         run: |
           make -C src/lib/micropython/mpy-cross
+          make -C src/lib/micropython/ports/unix aarch64=0 MICROPY_PY_SSL=0 MICROPY_PY_BTREE=0 FROZEN_MANIFEST= -j
 
       - name: Build Tang Nano 4K port (Simulation variant)
         run: |
@@ -48,6 +70,11 @@ jobs:
           cp src/ports/tang_nano_4k/build_hw/firmware.bin dist/firmware_hw.bin
           cp src/ports/tang_nano_4k/build_hw/firmware.elf dist/firmware_hw.elf
           cp src/fpga/bitstream/tang_nano_4k_m3.fs dist/tang_nano_4k_m3.fs
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Run Renode tests
         uses: antmicro/renode-test-action@v5


### PR DESCRIPTION
Implemented caching in the GitHub Actions build pipeline (`.github/workflows/build.yml`) for the ARM GNU Toolchain and the MicroPython core repository. The ARM toolchain (10.3-2021.10) is now manually downloaded and cached instead of being installed via `apt-get`. The MicroPython core cache includes pre-built `mpy-cross` and Reference Unix Port artifacts, with cache keys based on `runner.os` and the hash of `src/ports/tang_nano_4k/mpconfigport.h`. Verified YAML syntax and project structure before submission.

Fixes #182

---
*PR created automatically by Jules for task [228713681569286856](https://jules.google.com/task/228713681569286856) started by @chatelao*