### PR TITLE
Unify PSRAM Implementation and Correct RAM Documentation

### DIFF
--- a/RAM_USAGE.md
+++ b/RAM_USAGE.md
@@ -7,15 +7,14 @@ This document defines the formal usage plan for the various memory regions avail
 - **Region**: `0x20000000 - 0x200057FF`
 - **Role**: Primary Heap, Stack, and Static Data.
 - **MicroPython Usage**:
-    - **Stack**: 2 KB (at the top of SRAM: `0x20005800 - 0x20005FFF`).
+    - **Stack**: 2 KB (at the top of SRAM: `0x20005000 - 0x200057FF`).
     - **Data/BSS**: Statically allocated data.
     - **Primary Heap**: Initialized via `gc_init()`. This is the most efficient memory for object allocation.
 
 ## 2. External PSRAM (8 MB)
 
 - **Region**:
-    - **Hardware**: `0xA0000000 - 0xA07FFFFF`
-    - **Simulation**: `0x10000000 - 0x107FFFFF`
+    - **Hardware/Simulation**: `0xA0000000 - 0xA07FFFFF`
 - **Role**: Extended Heap.
 - **MicroPython Usage**:
     - **Extended Heap**: Initialized via `gc_add()`.
@@ -33,13 +32,13 @@ This document defines the formal usage plan for the various memory regions avail
 
 ## 4. Summary Table
 
-| Region | Capacity | Base (HW) | Base (Sim) | Usage |
-| :--- | :--- | :--- | :--- | :--- |
-| **Internal SRAM** | 22 KB | `0x20000000` | `0x20000000` | Stack, Static Data, Primary Heap |
-| **External PSRAM** | 8 MB | `0xA0000000` | `0x10000000` | Extended Heap |
+| Region | Capacity | Base Address | Usage |
+| :--- | :--- | :--- | :--- |
+| **Internal SRAM** | 22 KB | `0x20000000` | Stack, Static Data, Primary Heap |
+| **External PSRAM** | 8 MB | `0xA0000000` | Extended Heap |
 | **Fabric RAM** | ~1-9 KB | FPGA Defined | `0x10010000` | FPGA Communication (Reserved) |
 
 ## 5. Implementation Notes
 
 - **PSRAM Configuration**: To utilize the PSRAM in hardware, the **Gowin PSRAM Memory Interface** IP (W955D8MBYA) must be instantiated in the FPGA bitstream. It should be configured for **Memory Mapped Mode** (AHB interface) and mapped to the base address `0xA0000000`.
-- In the simulation environment (Renode), the `fpga_ram` peripheral is used to model the PSRAM at `0x10000000`.
+- In the simulation environment (Renode), the `fpga_ram` peripheral is used to model the PSRAM at `0xA0000000`.

--- a/RAM_XX_USAGE.md
+++ b/RAM_XX_USAGE.md
@@ -7,7 +7,7 @@ This document analyzes the current memory usage of the MicroPython port and eval
 The GW1NSR-4C integrated Cortex-M3 "Hard Core" has a primary internal SRAM space of **22 KB** (mapped at `0x20000000`). This memory is physically implemented using the SoC's Block SRAM (BSRAM) resources.
 
 ### Current Allocation:
-- **Stack**: 2 KB (at the top of SRAM: `0x20005800` - `0x20005FFF`)
+- **Stack**: 2 KB (at the top of SRAM: `0x20005000` - `0x200057FF`)
 - **Data/BSS**: ~1-2 KB (statically allocated)
 - **Heap**: ~18-19 KB (the remaining space for MicroPython objects)
 
@@ -36,21 +36,19 @@ The Tang Nano 4K board includes an integrated **64 Mbit (8 MB) PSRAM** chip conn
 - **Capacity**: 8 MB is **~360x larger** than the current 22 KB internal SRAM.
 - **Accessibility**: The SoC includes a dedicated **PSRAM Memory Interface** reachable via the **AHB2 Master bus** (base `0xA0000000`).
 
-### Requirements for Integration:
+### Current Implementation:
 1. **FPGA Bitstream**: The PSRAM controller IP must be instantiated in the FPGA fabric and routed to the physical PSRAM pins.
-2. **MicroPython Heap**: The MicroPython heap can be moved to the PSRAM region by updating `main.c` and the linker script, though this would incur a performance penalty (latency) compared to internal SRAM.
+2. **MicroPython Heap**: The MicroPython heap is already integrated as a split heap in `main.c`, utilizing the 8 MB region for extended object storage.
 
-## 5. Summary and Recommendation
+## 5. Summary and Implementation Status
 
-| Region | Capacity | Performance | Helpfulness | Recommendation |
+| Region | Capacity | Performance | Helpfulness | Status |
 | :--- | :--- | :--- | :--- | :--- |
-| **FastRAM** (Internal) | 22 KB | Highest | Essential | Already in use. |
-| **FSRAM** (Shadow) | ~1-9 KB | Moderate | Low | Do not use for general heap. |
-| **PSRAM** (External) | 8 MB | Lower | **Highest** | **High Priority** for future heap expansion. |
+| **FastRAM** (Internal) | 22 KB | Highest | Essential | **Implemented** (Stack, Data, Fast Heap) |
+| **FSRAM** (Shadow) | ~1-9 KB | Moderate | Low | Reserved for FPGA communication |
+| **PSRAM** (External) | 8 MB | Lower | **Highest** | **Implemented** (Large Heap) |
 
 ### Conclusion:
-- **FastRAM (Internal SRAM)**: No further action needed; it is already optimized for the stack and core heap.
-- **FSRAM**: Not recommended for general MicroPython usage due to FPGA resource exhaustion.
-- **PSRAM**: This is the only viable path for significant memory expansion. It would allow for much larger Python scripts, framebuffers, and complex data structures.
-
-**Next Step Recommendation**: Future development should focus on implementing a "PSRAM variant" of the firmware that initializes the PSRAM controller in the FPGA and utilizes the 8 MB region for the MicroPython heap.
+- **FastRAM (Internal SRAM)**: Optimized for the stack and core heap.
+- **FSRAM**: Reserved for small, specialized buffers or communication mailboxes between the M3 and FPGA.
+- **PSRAM**: Successfully integrated as an extended heap, allowing for much larger Python scripts, framebuffers, and complex data structures.

--- a/src/ports/tang_nano_4k/main.c
+++ b/src/ports/tang_nano_4k/main.c
@@ -23,11 +23,7 @@
 extern char _sheap, _eheap;
 static char *stack_top;
 
-#ifdef SIMULATION
-#define PSRAM_BASE (0x10000000)
-#else
 #define PSRAM_BASE (0xA0000000)
-#endif
 #define PSRAM_SIZE (8 * 1024 * 1024)
 
 int main(int argc, char **argv) {

--- a/test/compliance.resc
+++ b/test/compliance.resc
@@ -19,9 +19,9 @@ macro reset
 """
     sysbus LoadELF $bin
     # For booting from external flash, we need to set VTOR, SP and PC manually in Renode
-    sysbus.cpu VectorTableOffset 0x60000000
-    sysbus.cpu SP `sysbus ReadDoubleWord 0x60000000`
-    sysbus.cpu PC `sysbus ReadDoubleWord 0x60000004`
+    sysbus.cpu VectorTableOffset 0x00000000
+    sysbus.cpu SP `sysbus ReadDoubleWord 0x00000000`
+    sysbus.cpu PC `sysbus ReadDoubleWord 0x00000004`
 """
 
 runMacro $reset

--- a/test/tang_nano_4k.repl
+++ b/test/tang_nano_4k.repl
@@ -71,7 +71,6 @@ dma0: Memory.MappedMemory @ sysbus 0x40002C00
     size: 0x400
 
 // FPGA RAM - AHB2 Master region
-// Moved to 0x10000000 to fit in MicroPython 31-bit small ints
 // Simulated PSRAM (8MB)
-fpga_ram: Memory.MappedMemory @ sysbus 0x10000000
+fpga_ram: Memory.MappedMemory @ sysbus 0xA0000000
     size: 0x800000

--- a/test/tang_nano_4k.robot
+++ b/test/tang_nano_4k.robot
@@ -141,6 +141,7 @@ Verify FPGA DMA Implementation
     Should Match Regexp     ${ctrl_val}      0x0000000[45]
 
 Verify PSRAM Heap Expansion
+    [Tags]                  psram
     Setup MicroPython
     Start Emulation
     Wait For Line On Uart   MicroPython started on Tang Nano 4K
@@ -171,6 +172,7 @@ Verify PSRAM Heap Expansion
     Wait For Line On Uart   ALLOC_AFTER True
 
 Run MicroPython Compliance Tests
+    [Tags]                  compliance
     Execute Command         $repl = @${REPL}
     Execute Command         $bin = @${BIN}
     Execute Command         include @${RESC}


### PR DESCRIPTION
Verified and corrected the PSRAM implementation for the Tang Nano 4K port. Key changes include unifying the PSRAM base address at 0xA0000000 for both hardware and simulation, which is the correct address for the AHB2 Master bus on the GW1NSR-4C. Documentation was updated to reflect this unification and to correct the internal SRAM stack boundaries, ensuring they remain within the physical 22KB limit. Simulation tests confirm that MicroPython's heap correctly expands into the 8MB PSRAM and remains stable with the existing REPR_C object representation.

Fixes #184

---
*PR created automatically by Jules for task [1766752046924455707](https://jules.google.com/task/1766752046924455707) started by @chatelao*