### PR TITLE
Add M3 MicroPython Feature Support Matrix

### DIFF
--- a/M3_MICROPYTHON.md
+++ b/M3_MICROPYTHON.md
@@ -1,0 +1,32 @@
+# MicroPython Feature Support - Tang Nano 4K (Cortex-M3)
+
+This document lists the MicroPython features and modules supported by the ARM Cortex-M3 "Hard Core" on the Gowin GW1NSR-4C SoC. Features are categorized based on whether they rely on dedicated hardware blocks ("Hard") or are implemented entirely in the MicroPython software layer ("Soft").
+
+## Supported Features Matrix
+
+| Feature | Category | Description |
+| :--- | :--- | :--- |
+| **UART REPL** | Hard | Interactive Python prompt via UART0 (typically Pins 18/19). |
+| **GPIO (machine.Pin)** | Hard | Native digital Input, Output, and Open-Drain control. |
+| **Hardware Interrupts**| Hard | Edge-triggered interrupts on GPIO pins. |
+| **Timer (machine.Timer)**| Hard | Precise periodic and one-shot timing via CMSDK hardware timers. |
+| **PWM (machine.PWM)** | Hard | Pulse Width Modulation implemented via hardware timers. |
+| **ADC (machine.ADC)** | Hard | 12-bit Analog-to-Digital conversion for sensor interfacing. |
+| **I2C (machine.I2C)** | Hard | Hardware-backed I2C Master controller. |
+| **SoftI2C** | Soft | Bit-banged I2C protocol support on any GPIO pair. |
+| **SPI (machine.SPI)** | Hard | Hardware-backed SPI Master controller. |
+| **SoftSPI** | Soft | Bit-banged SPI protocol support on any GPIO trio. |
+| **RTC (machine.RTC)** | Hard | Real-Time Clock for calendar and alarm functionality. |
+| **WDT (machine.WDT)** | Hard | Hardware Watchdog Timer to prevent system lockups. |
+| **VFS (LittleFS2)** | Soft | Virtual File System support using LittleFS2 on external SPI Flash. |
+| **Power Management** | Hard | System `lightsleep`, `deepsleep`, and `reset` functionality. |
+| **FPGA Bridge** | Hard | Dedicated 16-bit bi-directional communication bridge to FPGA fabric. |
+| **FPGA DMA** | Hard | High-speed Direct Memory Access between M3 and FPGA. |
+| **Floating Point** | Soft | Software-emulated single-precision floating point arithmetic. |
+| **GC (Garbage Coll.)** | Soft | Automatic heap management and object lifecycle tracking. |
+
+## Feature Notes
+
+- **Hard Features**: These utilize the physical peripheral blocks integrated into the GW1NSR-4C's Cortex-M3 subsystem. They offer higher performance and lower CPU overhead.
+- **Soft Features**: These are implemented via MicroPython's core software or "bit-banging" techniques. While flexible (e.g., SoftI2C can use any pins), they consume more CPU cycles than their hardware counterparts.
+- **FPGA Integration**: Features like the `FPGABridge` and `FPGADMA` are unique to this SoC, allowing MicroPython to interact directly with custom logic implemented in the FPGA fabric.


### PR DESCRIPTION
This change introduces `M3_MICROPYTHON.md`, a detailed documentation of the MicroPython features supported by the ARM Cortex-M3 core on the Tang Nano 4K (GW1NSR-4C). 

The documentation includes a feature matrix that categorizes capabilities as either "Hard" (backed by dedicated hardware peripherals like UART, ADC, and Timers) or "Soft" (implemented in the MicroPython software layer, such as SoftI2C, Floating Point emulation, and Garbage Collection). It also highlights unique SoC-specific integrations like the FPGA Bridge and DMA.

Fixes #204

---
*PR created automatically by Jules for task [9570503468972878531](https://jules.google.com/task/9570503468972878531) started by @chatelao*