### PR TITLE
Set UIO to output and drive 0xAA in tt_echo example

### DIFF
--- a/examples/tt_echo/tt_echo.py
+++ b/examples/tt_echo/tt_echo.py
@@ -27,4 +27,13 @@ for val in test_values:
 
     time.sleep_ms(100)
 
+# Demonstrate reading the UIO value from the FPGA
+# 1. Configure bridge bits 8-15 as inputs (by clearing their output enable)
+#    Register: FPGA_GPIO_OUTENCLR (0x40010014)
+machine.mem32[0x40010014] = 0xFF00
+
+# 2. Read the value from the bridge and extract the upper 8 bits (UIO)
+uio_val = (bridge.read() >> 8) & 0xFF
+print("UIO value read from FPGA: 0x{:02X} (binary: {:08b})".format(uio_val, uio_val))
+
 print("Test Complete")

--- a/examples/tt_echo/tt_project.v
+++ b/examples/tt_echo/tt_project.v
@@ -20,8 +20,8 @@ module tt_um_minimal_echo (
     // Assign inputs directly to outputs
     assign uo_out  = ui_in;
 
-    // Use uio as inputs for now
-    assign uio_out = 8'b0;
-    assign uio_oe  = 8'b0;
+    // Set UIO to output and show b'10101010
+    assign uio_out = 8'b10101010;
+    assign uio_oe  = 8'b11111111;
 
 endmodule


### PR DESCRIPTION
Set UIO to output and drive 0xAA (10101010) in the tt_echo Verilog example and updated the MicroPython script to demonstrate reading this value.

Fixes #220

---
*PR created automatically by Jules for task [3998426277469322713](https://jules.google.com/task/3998426277469322713) started by @chatelao*