### PR TITLE
Add FPGA Bridge Usage Documentation

### DIFF
--- a/FPGA_BRIDGE_USAGE.md
+++ b/FPGA_BRIDGE_USAGE.md
@@ -1,0 +1,117 @@
+# FPGA Bridge Usage - Tang Nano 4K (GW1NSR-4C)
+
+This document provides a detailed guide on using MicroPython to interact with the FPGA fabric on the Sipeed Tang Nano 4K.
+
+## 1. GPIO Bridge (machine.FPGABridge)
+
+The `machine.FPGABridge` class provides low-level access to a 16-bit bi-directional bus between the Cortex-M3 and the FPGA fabric.
+
+### Initialization
+```python
+import machine
+bridge = machine.FPGABridge()
+```
+
+### Writing to the FPGA
+Writing a 16-bit value to the bridge:
+```python
+bridge.write(0xABCD)
+```
+
+### Reading from the FPGA
+Reading a 16-bit value from the bridge:
+```python
+val = bridge.read()
+print("Value from FPGA: 0x{:04x}".format(val))
+```
+
+### Direction Control
+By default, all bits are configured as outputs from the M3 to the FPGA. To read data *from* the FPGA, you must set the corresponding bits as inputs by clearing their output enable bits in the `FPGA_GPIO_OUTENCLR` register.
+
+| Register | Address | Description |
+| :--- | :--- | :--- |
+| `FPGA_GPIO_OUTENSET` | `0x40010010` | Set bits as outputs (1 = Output) |
+| `FPGA_GPIO_OUTENCLR` | `0x40010014` | Clear bits to inputs (1 = Input) |
+
+**Example: Configuring bits [15:8] as inputs:**
+```python
+# Clear output enable for bits [15:8]
+machine.mem32[0x40010014] = 0xFF00
+
+# Read 16-bit value (bits 8-15 now reflect FPGA signals)
+val = bridge.read()
+uio_val = (val >> 8) & 0xFF
+```
+
+---
+
+## 2. FPGA DMA (machine.FPGADMA)
+
+For high-speed data transfers between the M3's SRAM and the FPGA fabric, use the `machine.FPGADMA` class.
+
+### Usage
+```python
+import machine
+
+dma = machine.FPGADMA()
+src_addr = 0x20001000  # Example SRAM address
+dest_addr = 0x40002C00 # Example FPGA APB2 Slot address
+length = 1024          # Number of bytes
+
+# Perform transfer
+dma.transfer(src_addr, dest_addr, length)
+```
+
+The `transfer` method accepts both integer addresses and buffer-compatible objects (e.g., `bytearray`).
+
+---
+
+## 3. APB2 Expansion Slots
+
+The Cortex-M3 provides 12 slots on the APB2 bus, each 256 bytes wide, for custom register-mapped peripherals in the FPGA.
+
+| Slot | Base Address |
+| :--- | :--- |
+| Slot 1 | `0x40002400` |
+| Slot 2 | `0x40002500` |
+| ... | ... |
+| Slot 12 | `0x40002F00` |
+
+### MicroPython Access
+You can use `machine.mem32`, `machine.mem16`, or `machine.mem8` to access these slots.
+
+```python
+import machine
+
+# Write to Slot 1, Offset 0
+machine.mem32[0x40002400] = 0x12345678
+
+# Read from Slot 1, Offset 4
+val = machine.mem32[0x40002404]
+```
+
+---
+
+## 4. FPGA Interrupts (USER_INT)
+
+The FPGA can trigger interrupts on the M3 using dedicated `USER_INT` lines. These are mapped to specific IRQ numbers in the M3's NVIC.
+
+| IRQ # | Name |
+| :--- | :--- |
+| 1 | `USER_INT0` |
+| 3 | `USER_INT1` |
+| 4 | `USER_INT2` |
+| 7 | `USER_INT3` |
+| 13 | `USER_INT4` |
+| 14 | `USER_INT5` |
+
+### Handling Interrupts in MicroPython
+Currently, `machine.Pin` is the primary way to handle interrupts. To use `USER_INT` lines, they must be routed to a GPIO pin that supports interrupts in the FPGA fabric, or handled via low-level `machine.mem32` access to the NVIC registers (advanced).
+
+---
+
+## 5. Implementation Summary
+
+- **Address Range**: `0x40010000` (GPIO Bridge), `0x40002400` - `0x40002FFF` (APB2).
+- **Signal Mapping**: Refer to [M3_FPGA_INTEGRATIONS.md](M3_FPGA_INTEGRATIONS.md) for RTL wiring details.
+- **Tiny Tapeout**: Refer to [HOWTO_TT.md](HOWTO_TT.md) for specific mapping to Tiny Tapeout modules.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@
 - Keep an up to date file `ROADMAP.md` with the next 5 steps and all past steps having checkboxes.
 
 # Project structure
-- `/` - Keep root directory clean with relevant `.md` files: `AUDIT.md`, `COMPLIANCE_TESTS.md`, `GEMINI.md`, `HOWTO_TT.md`, `M3_FPGA_INTEGRATIONS.md`, `M3_MICROPYTHON.md`, `README.md`, `ROADMAP.md`, `SERIAL_PORT_ACCESS.md`, `TOOLCHAIN_SETUP.md`.
+- `/` - Keep root directory clean with relevant `.md` files: `AUDIT.md`, `COMPLIANCE_TESTS.md`, `FPGA_BRIDGE_USAGE.md`, `GEMINI.md`, `HOWTO_TT.md`, `M3_FPGA_INTEGRATIONS.md`, `M3_MICROPYTHON.md`, `README.md`, `ROADMAP.md`, `SERIAL_PORT_ACCESS.md`, `TOOLCHAIN_SETUP.md`.
 - `/definitions` - Datasheets and Standards to be used, download and convert to `.md` on first time read
 - `/examples` - Example MicroPython scripts and FPGA projects.
 - `/test` - Unit, System and End-2-End test concepts and cases to be executed after each change. Use Renode to verify the binaries.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a comprehensive overview of the port, including hardware details, installati
     - `SPI` / `SoftSPI`: Hardware and software SPI Master support.
     - `RTC`: Real-Time Clock for date and time management.
     - `WDT`: Hardware Watchdog Timer.
-    - `FPGABridge`: Low-level access to the 16-bit M3-to-FPGA GPIO bridge (See [HOWTO_TT.md](HOWTO_TT.md)).
+    - `FPGABridge`: Low-level access to the 16-bit M3-to-FPGA GPIO bridge (See [FPGA_BRIDGE_USAGE.md](FPGA_BRIDGE_USAGE.md)).
     - `Flash`: Block device interface for the onboard SPI Flash.
 - **Filesystem**: LittleFS (LFS2) on external SPI Flash.
 - **Runtime**: Garbage Collector, REPL over UART0.
@@ -58,6 +58,7 @@ For a comprehensive overview of the port, including hardware details, installati
 - `/.github` - Workflows for CI/CD.
 - `AUDIT.md` - Comprehensive project audit report.
 - `COMPLIANCE_TESTS.md` - MicroPython compliance testing results.
+- `FPGA_BRIDGE_USAGE.md` - Detailed guide on using MicroPython to interact with the FPGA.
 - `GEMINI.md` - Project goal and structural guidelines.
 - `HOWTO_TT.md` - Guide to loading and testing Tiny Tapeout modules.
 - `M3_FPGA_INTEGRATIONS.md` - Guide to communication interfaces between M3 and FPGA.

--- a/test/verify_structure.py
+++ b/test/verify_structure.py
@@ -16,6 +16,7 @@ def test_structure():
         'README.md',
         'ROADMAP.md',
         'src/fpga/bitstream/tang_nano_4k_m3.fs',
+        'FPGA_BRIDGE_USAGE.md',
         'GEMINI.md',
         'HOWTO_TT.md',
         'examples/blink/blink.py',


### PR DESCRIPTION
This PR introduces a new documentation file `FPGA_BRIDGE_USAGE.md` which provides a detailed guide on how to interact with the FPGA fabric from MicroPython on the Tang Nano 4K. It covers:
- Using `machine.FPGABridge` for 16-bit GPIO communication, including direction control.
- Using `machine.FPGADMA` for high-speed data transfers.
- Accessing APB2 Expansion Slots for custom register-mapped peripherals.
- Handling FPGA-to-M3 interrupts via `USER_INT` lines.

Additionally, the PR updates `README.md`, `GEMINI.md`, and the structural test script `test/verify_structure.py` to ensure the new file is correctly integrated and tracked.

Fixes #234

---
*PR created automatically by Jules for task [356274667538147490](https://jules.google.com/task/356274667538147490) started by @chatelao*