### PR TITLE
Add Video to APB bridge documentation

### DIFF
--- a/M3_FPGA_INTEGRATIONS.md
+++ b/M3_FPGA_INTEGRATIONS.md
@@ -41,6 +41,8 @@ The M3's GPIO signals must be instantiated in your RTL. In Gowin EDA, these appe
 ### Variant 2: APB2 Expansion Slots (Register-Mapped)
 The M3 provides 12 slots of 256 bytes each on the APB2 bus. This allows you to implement custom register-mapped peripherals in the FPGA.
 
+**Reference Video:** [Custom APB2 Peripherals on Tang Nano 4K](https://youtu.be/6wGrsRgHWBU)
+
 **Register Map:**
 | Slot | Base Address |
 | :--- | :--- |


### PR DESCRIPTION
This change updates the `M3_FPGA_INTEGRATIONS.md` file to include a reference YouTube video (`https://youtu.be/6wGrsRgHWBU`) specifically for the "Variant 2: APB2 Expansion Slots (Register-Mapped)" section. This video provides a practical walkthrough of creating custom APB2 peripherals on the Tang Nano 4K.

The change was verified by running `python3 test/verify_structure.py` to ensure no documentation structural constraints were violated.

Fixes #236

---
*PR created automatically by Jules for task [8906108277952805254](https://jules.google.com/task/8906108277952805254) started by @chatelao*