### PR TITLE
Expand explanation of TT control signals in HOWTO_TT.md

### DIFF
--- a/HOWTO_TT.md
+++ b/HOWTO_TT.md
@@ -28,7 +28,10 @@ To accommodate the 24 TT signals (8 in, 8 out, 8 bidir) within a 16-bit bridge, 
 | `[7:0]` | `ui_in` / `uo_out` | Multiplexed or shared data bus. |
 | `[15:8]` | `uio_in` / `uio_out` | Bidirectional I/O bus. |
 
-*Note: `ena`, `clk`, and `rst_n` are typically managed by the FPGA wrapper (e.g., using the system clock or a dedicated control register).*
+*Note on Control Signals:* The `machine.FPGABridge` provides only 16 bits of connectivity. Since a full TT interface (24 data/IO pins + 3 control pins) exceeds this, we recommend managing `ena`, `clk`, and `rst_n` directly in the FPGA wrapper:
+*   **`clk`**: Should be connected to a hardware clock (e.g., the 27MHz crystal or M3 `HCLK`) for stability and speed.
+*   **`rst_n`**: Typically tied to the system reset to ensure the module initializes on power-up.
+*   **`ena`**: Can be tied to `1'b1` (always enabled) or controlled via a separate **APB2 Register** (see [M3_FPGA_INTEGRATIONS.md](M3_FPGA_INTEGRATIONS.md)) to save bridge bits.
 
 ## 3. FPGA Wrapper (Verilog)
 


### PR DESCRIPTION
This change adds a detailed explanation to HOWTO_TT.md regarding the management of ena, clk, and rst_n signals for Tiny Tapeout modules. It clarifies the 16-bit bridge constraint, the need for hardware-managed clocks for performance, and the option to use APB2 registers for software control.

Fixes #248

---
*PR created automatically by Jules for task [18087254739407788524](https://jules.google.com/task/18087254739407788524) started by @chatelao*