### PR TITLE
Split CI Build and Test Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,39 +75,37 @@ jobs:
           cp src/ports/tang_nano_4k/build_split/firmware.elf dist/firmware_split.elf
           cp src/fpga/bitstream/tang_nano_4k_m3.fs dist/tang_nano_4k_m3.fs
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Run Renode tests
-        uses: antmicro/renode-test-action@v5
-        with:
-          tests-to-run: |
-            test/tang_nano_4k.robot
-            test/examples/test_blink.robot
-            test/examples/test_tt_echo.robot
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-and-tests
-          path: |
-            dist/firmware_sim.bin
-            dist/firmware_sim.elf
-            dist/firmware_hw.bin
-            dist/firmware_hw.elf
-            dist/firmware_split_int.bin
-            dist/firmware_split_ext.bin
-            dist/firmware_split.elf
-            dist/tang_nano_4k_m3.fs
-            COMPLIANCE_TESTS.md
-            compliance_output.log
-            renode_output.log
-          if-no-files-found: warn
+          name: firmware-dist
+          path: dist/
+          if-no-files-found: error
+
+  test:
+    needs: build
+    uses: ./.github/workflows/test.yml
+
+  release:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-dist
+          path: dist
+
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results
+          path: .
 
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -122,5 +117,8 @@ jobs:
             dist/firmware_split_ext.bin
             dist/firmware_split.elf
             dist/tang_nano_4k_m3.fs
+            COMPLIANCE_TESTS.md
+            compliance_output.log
+            renode_output.log
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-dist
+          path: dist
+
+      - name: Prepare firmware for tests
+        run: |
+          mkdir -p src/ports/tang_nano_4k/build
+          cp dist/firmware_sim.elf src/ports/tang_nano_4k/build/firmware.elf
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache MicroPython core
+        id: cache-micropython
+        uses: actions/cache@v4
+        with:
+          path: src/lib/micropython
+          key: micropython-v1.24.1-${{ runner.os }}-${{ hashFiles('src/ports/tang_nano_4k/mpconfigport.h') }}
+
+      - name: Clone MicroPython core
+        if: steps.cache-micropython.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v1.24.1 https://github.com/micropython/micropython.git src/lib/micropython
+
+      - name: Run Renode tests
+        uses: antmicro/renode-test-action@v5
+        with:
+          tests-to-run: |
+            test/tang_nano_4k.robot
+            test/examples/test_blink.robot
+            test/examples/test_tt_echo.robot
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            COMPLIANCE_TESTS.md
+            compliance_output.log
+            renode_output.log
+            report.html
+            log.html
+            robot_output.xml
+          if-no-files-found: warn


### PR DESCRIPTION
This PR splits the monolithic GitHub Actions workflow into two files: `build.yml` and `test.yml`. 

1. **`test.yml`**: A new reusable workflow that handles Renode and compliance testing. It downloads the built firmware from the caller and prepares the environment (including a cached MicroPython core) to run the full test suite.
2. **`build.yml`**: Refactored to focus on compilation of all firmware variants. It now calls `test.yml` after a successful build. The `release` job is updated to collect both the firmware artifacts from the `build` job and the test logs from the `test` job, ensuring all relevant assets are included in GitHub Releases.

This separation improves CI organization and allows for better modularity in the testing process.

Fixes #259

---
*PR created automatically by Jules for task [17620501559522809085](https://jules.google.com/task/17620501559522809085) started by @chatelao*