### PR TITLE
Expose TT signals to physical pins on Tang Nano 4K

### DIFF
--- a/examples/tt_echo/tang_nano_4k_tt.cst
+++ b/examples/tt_echo/tang_nano_4k_tt.cst
@@ -1,0 +1,72 @@
+// Physical Constraints for Tiny Tapeout on Tang Nano 4K
+
+IO_LOC "clk" 45;
+IO_PORT "clk" IO_TYPE=LVCMOS33;
+
+IO_LOC "uart0_tx" 18;
+IO_PORT "uart0_tx" IO_TYPE=LVCMOS33;
+IO_LOC "uart0_rx" 19;
+IO_PORT "uart0_rx" IO_TYPE=LVCMOS33;
+
+// UI IN (8 pins)
+IO_LOC "ui_in[0]" 27;
+IO_LOC "ui_in[1]" 28;
+IO_LOC "ui_in[2]" 29;
+IO_LOC "ui_in[3]" 30;
+IO_LOC "ui_in[4]" 31;
+IO_LOC "ui_in[5]" 32;
+IO_LOC "ui_in[6]" 33;
+IO_LOC "ui_in[7]" 34;
+IO_PORT "ui_in[0]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[1]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[2]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[3]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[4]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[5]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[6]" IO_TYPE=LVCMOS33;
+IO_PORT "ui_in[7]" IO_TYPE=LVCMOS33;
+
+// UO OUT (8 pins)
+IO_LOC "uo_out[0]" 41;
+IO_LOC "uo_out[1]" 42;
+IO_LOC "uo_out[2]" 43;
+IO_LOC "uo_out[3]" 44;
+IO_LOC "uo_out[4]" 4;
+IO_LOC "uo_out[5]" 3;
+IO_LOC "uo_out[6]" 2;
+IO_LOC "uo_out[7]" 1;
+IO_PORT "uo_out[0]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[1]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[2]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[3]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[4]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[5]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[6]" IO_TYPE=LVCMOS33;
+IO_PORT "uo_out[7]" IO_TYPE=LVCMOS33;
+
+// UIO (8 pins)
+IO_LOC "uio[0]" 13;
+IO_LOC "uio[1]" 14;
+IO_LOC "uio[2]" 15;
+IO_LOC "uio[3]" 16;
+IO_LOC "uio[4]" 17;
+IO_LOC "uio[5]" 20;
+IO_LOC "uio[6]" 21;
+IO_LOC "uio[7]" 22;
+IO_PORT "uio[0]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[1]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[2]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[3]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[4]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[5]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[6]" IO_TYPE=LVCMOS33;
+IO_PORT "uio[7]" IO_TYPE=LVCMOS33;
+
+IO_LOC "ena" 10;
+IO_PORT "ena" IO_TYPE=LVCMOS33;
+
+IO_LOC "tt_clk" 11;
+IO_PORT "tt_clk" IO_TYPE=LVCMOS33;
+
+IO_LOC "rst_n" 46;
+IO_PORT "rst_n" IO_TYPE=LVCMOS33;

--- a/examples/tt_echo/top.v
+++ b/examples/tt_echo/top.v
@@ -1,0 +1,89 @@
+/*
+ * Top-level module for Tiny Tapeout on Tang Nano 4K
+ * Integrates Cortex-M3 Hard Core with TT Wrapper and physical pins.
+ */
+
+`default_nettype none
+
+module top (
+    input  wire       clk,          // 27MHz Oscillator (Pin 45)
+
+    // UART0 (MicroPython REPL)
+    output wire       uart0_tx,     // Pin 18
+    input  wire       uart0_rx,     // Pin 19
+
+    // Tiny Tapeout External Interface
+    input  wire [7:0] ui_in,        // Pins 27-34
+    output wire [7:0] uo_out,       // Pins 41-44, 4-1
+    inout  wire [7:0] uio,          // Pins 13-17, 20-22
+    input  wire       ena,          // Pin 10
+    input  wire       tt_clk,       // Pin 11
+    input  wire       rst_n         // Pin 46
+);
+
+    // APB2 Expansion Bus Signals (Slot 1)
+    wire        m3_pclk;
+    wire        m3_presetn;
+    wire [11:0] m3_paddr;
+    wire        m3_psel;
+    wire        m3_penable;
+    wire        m3_pwrite;
+    wire [31:0] m3_pwdata;
+    wire [31:0] m3_prdata;
+    wire        m3_pready;
+
+    // Instantiate Gowin EMPU M3
+    // Note: Port names are representative of the Gowin EMPU M3 IP configuration
+    Gowin_EMPU_M3 m3_inst (
+        .sys_clk   (clk),
+        .uart0_tx  (uart0_tx),
+        .uart0_rx  (uart0_rx),
+
+        // APB2 Slot 1 (Base: 0x40002400)
+        .pclk      (m3_pclk),
+        .presetn   (m3_presetn),
+        .paddr     (m3_paddr),
+        .psel      (m3_psel),
+        .penable   (m3_penable),
+        .pwrite    (m3_pwrite),
+        .pwdata    (m3_pwdata),
+        .prdata    (m3_prdata),
+        .pready    (m3_pready)
+    );
+
+    // Tri-state logic for Bi-directional UIO pins
+    wire [7:0] uio_in_ext;
+    wire [7:0] uio_out_ext;
+    wire [7:0] uio_oe_ext;
+
+    genvar i;
+    generate
+        for (i = 0; i < 8; i = i + 1) begin : gen_uio
+            assign uio[i] = uio_oe_ext[i] ? uio_out_ext[i] : 1'bz;
+            assign uio_in_ext[i] = uio[i];
+        end
+    endgenerate
+
+    // TT Wrapper Instance
+    tt_m3_wrapper tt_wrap_inst (
+        .PCLK     (m3_pclk),
+        .PRESETn  (m3_presetn),
+        .PADDR    (m3_paddr[7:0]),
+        .PSEL     (m3_psel),
+        .PENABLE  (m3_penable),
+        .PWRITE   (m3_pwrite),
+        .PWDATA   (m3_pwdata),
+        .PRDATA   (m3_prdata),
+        .PREADY   (m3_pready),
+
+        .ui_in_ext  (ui_in),
+        .uo_out_ext (uo_out),
+        .uio_in_ext (uio_in_ext),
+        .uio_out_ext(uio_out_ext),
+        .uio_oe_ext (uio_oe_ext),
+        .ena_ext    (ena),
+        .clk_ext    (tt_clk),
+        .rst_n_ext  (rst_n)
+    );
+
+endmodule

--- a/examples/tt_echo/tt_wrapper.v
+++ b/examples/tt_echo/tt_wrapper.v
@@ -1,13 +1,14 @@
 /*
  * APB2 Wrapper for Tiny Tapeout (TT) on Tang Nano 4K
  *
- * This wrapper connects a standard TT module to the M3 APB2 expansion bus (Slot 1).
+ * This wrapper connects a standard TT module to the M3 APB2 expansion bus (Slot 1)
+ * AND exposes the signals to external FPGA pins.
  *
  * Register Map (Base: 0x40002400):
- *   0x00: DATA    (W: ui_in, R: uo_out)
- *   0x04: UIO_DATA (W: uio_in, R: uio_out)
+ *   0x00: DATA    (W: ui_in_m3, R: uo_out)
+ *   0x04: UIO_DATA (W: uio_in_m3, R: uio_out)
  *   0x08: UIO_OE   (R: uio_oe)
- *   0x0C: CTRL     (W/R: [0]=clk, [1]=rst_n, [2]=ena)
+ *   0x0C: CTRL     (W/R: [0]=clk_m3, [1]=rst_n_m3, [2]=ena_m3)
  */
 
 `default_nettype none
@@ -21,32 +22,54 @@ module tt_m3_wrapper (
     input  wire        PWRITE,  // APB Write
     input  wire [31:0] PWDATA,  // APB Write Data
     output reg  [31:0] PRDATA,  // APB Read Data
-    output wire        PREADY   // APB Ready
+    output wire        PREADY,  // APB Ready
+
+    // External Pin Interface
+    input  wire [7:0]  ui_in_ext,
+    output wire [7:0]  uo_out_ext,
+    input  wire [7:0]  uio_in_ext,
+    output wire [7:0]  uio_out_ext,
+    output wire [7:0]  uio_oe_ext,
+    input  wire        ena_ext,
+    input  wire        clk_ext,
+    input  wire        rst_n_ext
 );
 
     assign PREADY = 1'b1;
 
-    // Registers (W)
-    reg  [7:0] ui_in;   // Input to TT module
-    reg  [7:0] uio_in;  // Input (path) to TT module
-    reg  [2:0] ctrl;    // [0]=clk, [1]=rst_n (Active Low), [2]=ena
+    // Registers (W from M3)
+    reg  [7:0] ui_in_m3;
+    reg  [7:0] uio_in_m3;
+    reg  [2:0] ctrl_m3;    // [0]=clk, [1]=rst_n, [2]=ena
+
+    // Combined Signals to TT module
+    wire [7:0] ui_in   = ui_in_m3 | ui_in_ext;
+    wire [7:0] uio_in  = uio_in_m3 | uio_in_ext;
+    wire       ena     = ctrl_m3[2] | ena_ext;
+    wire       clk     = ctrl_m3[0] | clk_ext;
+    wire       rst_n   = ctrl_m3[1] & rst_n_ext;
 
     // Wires from TT module (R)
-    wire [7:0] uo_out;  // Output from TT module
-    wire [7:0] uio_out; // Output (path) from TT module
-    wire [7:0] uio_oe;  // Output Enable from TT module
+    wire [7:0] uo_out;
+    wire [7:0] uio_out;
+    wire [7:0] uio_oe;
+
+    // Route outputs to external pins
+    assign uo_out_ext  = uo_out;
+    assign uio_out_ext = uio_out;
+    assign uio_oe_ext  = uio_oe;
 
     // --- APB Write Logic ---
     always @(posedge PCLK or negedge PRESETn) begin
         if (!PRESETn) begin
-            ui_in   <= 8'h0;
-            uio_in  <= 8'h0;
-            ctrl    <= 3'h0; // Reset active (rst_n=0), Ena=0, Clk=0
+            ui_in_m3   <= 8'h0;
+            uio_in_m3  <= 8'h0;
+            ctrl_m3    <= 3'h0; // Reset active (rst_n=0), Ena=0, Clk=0
         end else if (PSEL && PENABLE && PWRITE) begin
             case (PADDR[3:0])
-                4'h0: ui_in  <= PWDATA[7:0];
-                4'h4: uio_in <= PWDATA[7:0];
-                4'hC: ctrl   <= PWDATA[2:0];
+                4'h0: ui_in_m3  <= PWDATA[7:0];
+                4'h4: uio_in_m3 <= PWDATA[7:0];
+                4'hC: ctrl_m3   <= PWDATA[2:0];
             endcase
         end
     end
@@ -57,22 +80,21 @@ module tt_m3_wrapper (
             4'h0:    PRDATA = {24'h0, uo_out};
             4'h4:    PRDATA = {24'h0, uio_out};
             4'h8:    PRDATA = {24'h0, uio_oe};
-            4'hC:    PRDATA = {29'h0, ctrl};
+            4'hC:    PRDATA = {29'h0, ctrl_m3};
             default: PRDATA = 32'h0;
         endcase
     end
 
     // --- Tiny Tapeout Module Instantiation ---
-    // Note: Change 'tt_um_minimal_echo' to your actual TT module name
     tt_um_minimal_echo tt_inst (
         .ui_in  (ui_in),
         .uo_out (uo_out),
         .uio_in (uio_in),
         .uio_out(uio_out),
         .uio_oe (uio_oe),
-        .ena    (ctrl[2]),
-        .clk    (ctrl[0]),
-        .rst_n  (ctrl[1])
+        .ena    (ena),
+        .clk    (clk),
+        .rst_n  (rst_n)
     );
 
 endmodule


### PR DESCRIPTION
This change exposes the Tiny Tapeout (TT) interface (ui, uo, uio, ena, clk, rst_n) to the physical pins of the Tang Nano 4K board while preserving the UART0 connection used by MicroPython. A new top-level Verilog module and a corresponding physical constraint file (.cst) have been added to the `examples/tt_echo/` directory.

Fixes #270

---
*PR created automatically by Jules for task [3236076877705288758](https://jules.google.com/task/3236076877705288758) started by @chatelao*