### PR TITLE
Explain openfpgaflasher options in HOWTO_TINY_TAPEOUT.md

### DIFF
--- a/HOWTO_TINY_TAPEOUT.md
+++ b/HOWTO_TINY_TAPEOUT.md
@@ -227,6 +227,11 @@ To flash the FPGA bitstream, the internal MCU firmware, and the external flash f
 openfpgaflasher -b <bitstream.fs> -m <firmware_int.bin> -e <firmware_ext.bin>
 ```
 
+**Options:**
+*   `-b <bitstream.fs>`: Path to the FPGA bitstream file.
+*   `-m <firmware_int.bin>`: Path to the internal MCU firmware (vectors and reset handler).
+*   `-e <firmware_ext.bin>`: Path to the external SPI flash firmware (MicroPython runtime).
+
 **Example from the project root:**
 ```bash
 openfpgaflasher examples/tt_echo/tt_echo.fs -m src/ports/tang_nano_4k/build/firmware_int.bin -e src/ports/tang_nano_4k/build/firmware_ext.bin


### PR DESCRIPTION
This PR adds documentation for the `openfpgaflasher` command-line options in `HOWTO_TINY_TAPEOUT.md`. 

Specifically, it adds explanations for:
- `-b`: FPGA bitstream file (`.fs`).
- `-m`: Internal MCU firmware (`firmware_int.bin`).
- `-e`: External SPI flash firmware (`firmware_ext.bin`).

These options are used for simultaneous flashing of the FPGA and both parts of the MicroPython firmware on the Tang Nano 4K.

Fixes #279

---
*PR created automatically by Jules for task [652063628921419455](https://jules.google.com/task/652063628921419455) started by @chatelao*