### PR TITLE
Add memory map and bitfield documentation to tt_echo README

### DIFF
--- a/examples/tt_echo/README.md
+++ b/examples/tt_echo/README.md
@@ -12,6 +12,53 @@ This example demonstrates a minimal integration of a Tiny Tapeout (TT) module in
 - `tt_wrapper.v`: A Verilog wrapper that implements an APB2 slave and maps its registers to the Tiny Tapeout signal interface.
 - `tt_project.v`: A simple Tiny Tapeout compatible module that echoes `ui_in` to `uo_out` and sets a fixed value for `uio_out`.
 
+## Register Map
+
+The TT module is mapped to **APB2 Slot 1** (Base Address: `0x40002400`).
+
+| Register | Offset | Address | Access | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `DATA` | `0x00` | `0x40002400` | RW | Write: `ui_in` / Read: `uo_out` |
+| `UIO_DATA` | `0x04` | `0x40002404` | RW | Write: `uio_in` / Read: `uio_out` |
+| `UIO_OE` | `0x08` | `0x40002408` | RO | Read: `uio_oe` (8-bit) |
+| `CTRL` | `0x0C` | `0x4000240C` | RW | Control: [0]=clk, [1]=rst_n, [2]=ena |
+
+## Register Bitfields
+
+### `DATA` Register (Offset: `0x00`)
+```wavedrom
+{ "reg": [
+  {"name": "ui_in (W) / uo_out (R)", "bits": 8},
+  {"bits": 24}
+], "config": {"bits": 32}}
+```
+
+### `UIO_DATA` Register (Offset: `0x04`)
+```wavedrom
+{ "reg": [
+  {"name": "uio_in (W) / uio_out (R)", "bits": 8},
+  {"bits": 24}
+], "config": {"bits": 32}}
+```
+
+### `UIO_OE` Register (Offset: `0x08`)
+```wavedrom
+{ "reg": [
+  {"name": "uio_oe (R)", "bits": 8},
+  {"bits": 24}
+], "config": {"bits": 32}}
+```
+
+### `CTRL` Register (Offset: `0x0C`)
+```wavedrom
+{ "reg": [
+  {"name": "clk", "bits": 1},
+  {"name": "rst_n", "bits": 1},
+  {"name": "ena", "bits": 1},
+  {"bits": 29}
+], "config": {"bits": 32}}
+```
+
 ## How it Works
 
 1.  **MicroPython** runs on the **Cortex-M3** hard core.


### PR DESCRIPTION
This PR adds detailed memory-mapped interface documentation to the `tt_echo` example. It includes a table mapping registers to their offsets and addresses in APB2 Slot 1, and uses WaveDrom bitfield diagrams to document the bitwise layout of the `DATA`, `UIO_DATA`, `UIO_OE`, and `CTRL` registers.

Fixes #291

---
*PR created automatically by Jules for task [1159842132932695231](https://jules.google.com/task/1159842132932695231) started by @chatelao*