### PR TITLE
Add Unsupported Features and Gaps to AUDIT.md

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -8,6 +8,8 @@ The port is **feature-complete** according to its established roadmap, providing
 
 ## 2. Feature Matrix
 
+### 2.1 Supported Features Matrix
+
 | Feature | Category | Status | Implementation Detail |
 | :--- | :--- | :--- | :--- |
 | **Core REPL** | System | Complete | UART0 (115200 8N1) |
@@ -25,6 +27,20 @@ The port is **feature-complete** according to its established roadmap, providing
 | **DMA** | Specialized | Complete | DMA support for FPGA-M3 data transfers |
 | **RISC-V Co-proc**| Specialized | Complete | SERV and NEORV32 co-processor integration examples |
 | **Tiny Tapeout** | Specialized | Complete | Support for loading and testing TT modules (ui/uo/uio) |
+
+### 2.2 Unsupported Features / Gaps
+
+| Feature | Category | Status | Reason / Detail |
+| :--- | :--- | :--- | :--- |
+| **Networking** | Connectivity | Unsupported | No hardware MAC/PHY or software stack (`network`, `usocket`). |
+| **Bluetooth** | Connectivity | Unsupported | No hardware support on GW1NSR-4C. |
+| **Hardware FPU** | Core | Unsupported | Cortex-M3 lacks a hardware FPU; uses software emulation. |
+| **AsyncIO** | Software | Disabled | `asyncio` disabled to conserve flash space. |
+| **Math Module** | Software | Disabled | `math` module disabled; basic arithmetic only. |
+| **JSON / Regex** | Software | Disabled | `ujson` and `ure` modules disabled to save space. |
+| **Complex Numbers**| Software | Disabled | `complex` type support is not compiled in. |
+| **Advanced Built-ins**| Software | Disabled | `enumerate`, `filter`, `reversed`, `property` etc., are disabled. |
+| **Built-in Help** | System | Disabled | Interactive `help()` system removed to save flash. |
 
 ## 3. Architecture and Optimization Review
 


### PR DESCRIPTION
I have updated `AUDIT.md` to include a comprehensive list of unsupported features and gaps in the MicroPython port for the Tang Nano 4K. 

Key changes:
- Reorganized the Feature Matrix section into two subsections: '2.1 Supported Features Matrix' and '2.2 Unsupported Features / Gaps'.
- Added a new table in section 2.2 detailing hardware gaps (Networking, Bluetooth, FPU) and software features disabled to fit the 128KB flash limit (AsyncIO, Math, JSON, Regex, etc.).
- Verified the updates by reading the file and running the `test/verify_structure.py` script.
- Conducted a code review and recorded relevant project memories.

Fixes #292

---
*PR created automatically by Jules for task [8908314076476961952](https://jules.google.com/task/8908314076476961952) started by @chatelao*