### PR TITLE
Reformat TT_HELPERS.md to table format

### DIFF
--- a/examples/tt_echo/TT_HELPERS.md
+++ b/examples/tt_echo/TT_HELPERS.md
@@ -4,29 +4,14 @@ This library provides a simplified interface for interacting with Tiny Tapeout d
 
 ## Functions
 
-### `tt.tt_init()`
-Initialize TT: De-assert reset, Enable design, Clock low.
-
-### `tt.set_clock(val)`
-Set the clock state (True=High, False=Low).
-
-### `tt.set_ui(val)`
-Set the 8-bit ui_in value.
-
-### `tt.set_uio(val)`
-Set the 8-bit uio_in value.
-
-### `tt.set_uoe(val)`
-Set the 8-bit uio_oe value (Note: Current hardware may treat this as Read-Only).
-
-### `tt.get_uo()`
-Read the 8-bit uo_out value.
-
-### `tt.get_uio()`
-Read the 8-bit uio_out value.
-
-### `tt.get_uoe()`
-Read the 8-bit uio_oe value.
-
-### `tt.send(ui, uio=None)`
-Set inputs, toggle clock (High then Low), and return uo_out.
+| Function | Description |
+| --- | --- |
+| `tt.tt_init()` | Initialize TT: De-assert reset, Enable design, Clock low. |
+| `tt.set_clock(val)` | Set the clock state (True=High, False=Low). |
+| `tt.set_ui(val)` | Set the 8-bit ui_in value. |
+| `tt.set_uio(val)` | Set the 8-bit uio_in value. |
+| `tt.set_uoe(val)` | Set the 8-bit uio_oe value (Note: Current hardware may treat this as Read-Only). |
+| `tt.get_uo()` | Read the 8-bit uo_out value. |
+| `tt.get_uio()` | Read the 8-bit uio_out value. |
+| `tt.get_uoe()` | Read the 8-bit uio_oe value. |
+| `tt.send(ui, uio=None)` | Set inputs, toggle clock (High then Low), and return uo_out. |

--- a/generate_tt_docs.py
+++ b/generate_tt_docs.py
@@ -20,6 +20,8 @@ try:
     docs_content += "This library provides a simplified interface for interacting with Tiny Tapeout designs via the APB2 bus (Slot 1).\n\n"
 
     docs_content += "## Functions\n\n"
+    docs_content += "| Function | Description |\n"
+    docs_content += "| --- | --- |\n"
 
     # List of functions in the order we want to display them
     functions = [
@@ -38,9 +40,10 @@ try:
         if hasattr(tt, name):
             obj = getattr(tt, name)
             sig = inspect.signature(obj)
-            doc = obj.__doc__ or "No documentation available."
-            docs_content += f"### `tt.{name}{sig}`\n"
-            docs_content += f"{doc}\n\n"
+            doc = inspect.getdoc(obj) or "No documentation available."
+            # Clean up the docstring for Markdown table compatibility
+            doc = doc.replace('\n', ' ').replace('|', '\\|')
+            docs_content += f"| `tt.{name}{sig}` | {doc} |\n"
 
     # Ensure output directory exists (it should be examples/tt_echo)
     output_path = os.path.join(tt_path, 'TT_HELPERS.md')


### PR DESCRIPTION
Reformatted the Tiny Tapeout helper library documentation (`TT_HELPERS.md`) into a Markdown table for better readability. Also updated the `generate_tt_docs.py` script to maintain this format in future builds, including robust docstring sanitization. Verified project structure with `test/verify_structure.py`.

Fixes #294

---
*PR created automatically by Jules for task [1770708740365144787](https://jules.google.com/task/1770708740365144787) started by @chatelao*