### PR TITLE
Exclude monolithic and ELF binaries from release packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,13 +109,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/firmware_sim.bin
-            dist/firmware_sim.elf
-            dist/firmware_hw.bin
-            dist/firmware_hw.elf
             dist/firmware_split_int.bin
             dist/firmware_split_ext.bin
-            dist/firmware_split.elf
             dist/tang_nano_4k_m3.fs
             COMPLIANCE_TESTS.md
             compliance_output.log


### PR DESCRIPTION
This change updates the GitHub Actions build workflow to exclude several binary and ELF files from being included in the final release packages. The removed files are:
- firmware_hw.bin
- firmware_hw.elf
- firmware_sim.bin
- firmware_sim.elf
- firmware_split.elf

This streamlines the release by focusing on the assets required for hardware deployment using the GoWin Programmer and documented split-flash architecture.

Fixes #300

---
*PR created automatically by Jules for task [8291583077842889696](https://jules.google.com/task/8291583077842889696) started by @chatelao*