### PR TITLE
Add Open-Source FPGA Toolchain Documentation

### DIFF
--- a/HOWTO_TINY_TAPEOUT.md
+++ b/HOWTO_TINY_TAPEOUT.md
@@ -25,9 +25,8 @@ cp -r examples/tt_echo examples/my_tt_project
     make -C src/ports/tang_nano_4k/
     ```
 2.  **FPGA Bitstream**:
-    - Open Gowin EDA and create a new project.
-    - Add `tt_wrapper.v` and `tt_project.v` to the project.
-    - Run "Place & Route" to generate the `.fs` bitstream.
+    - **Option A (Official)**: Use Gowin EDA (Proprietary). Add `tt_wrapper.v` and `tt_project.v` to a new project and run "Place & Route".
+    - **Option B (Open-Source)**: Use Yosys, nextpnr-himbaechel, and gowin_pack. (See Section 3 for details).
 
 ### Step 4: Install Everything
 Use `openfpgaflasher` to load the bitstream and MicroPython firmware in one command:
@@ -57,7 +56,32 @@ You have two alternatives to connect the Cortex-M3 UART0 (routed to Pins 18/19 b
 
 ---
 
-## 3. Advanced Details & Reference
+## 3. Open-Source FPGA Toolchain (Alternative)
+
+For an entirely open-source workflow without Gowin EDA, you can use **Project Apicula**, **Yosys**, and **nextpnr-himbaechel** to generate the bitstream.
+
+### Synthesis (Yosys)
+```bash
+yosys -p "read_verilog examples/my_tt_project/tt_wrapper.v examples/my_tt_project/tt_project.v; synth_gowin -json tt_project.json"
+```
+
+### Place & Route (nextpnr-himbaechel)
+```bash
+nextpnr-himbaechel --json tt_project.json \
+                   --write tt_pnr.json \
+                   --device GW1NSR-LV4CQN48PC7/I6 \
+                   --vopt family=GW1NS-4 \
+                   --vopt cst=examples/my_tt_project/tt_echo.cst
+```
+
+### Pack (gowin_pack)
+```bash
+gowin_pack -d GW1NS-4 -o tt_project.fs tt_pnr.json
+```
+
+---
+
+## 4. Advanced Details & Reference
 
 ### Tiny Tapeout Interface Mapping
 The standard TT interface is mapped to the M3 via **APB2 Slot 1** (`0x40002400`).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For a comprehensive overview of the port, including hardware details, installati
 - `M3_MICROPYTHON.md` - Supported MicroPython features and port guide.
 - `ROADMAP.md` - Progress tracking and future steps.
 - `SERIAL_PORT_ACCESS.md` - Guide to accessing the Cortex-M3 serial port.
-- `TOOLCHAIN_SETUP.md` - Instructions for setting up the ARM toolchain.
+- [`TOOLCHAIN_SETUP.md`](TOOLCHAIN_SETUP.md) - Instructions for setting up the ARM and FPGA toolchains.
 
 ## UART Configuration
 The MicroPython REPL is accessible via the Cortex-M3 UART0 peripheral.

--- a/TOOLCHAIN_SETUP.md
+++ b/TOOLCHAIN_SETUP.md
@@ -1,0 +1,98 @@
+# Toolchain Setup Guide
+
+This document provides instructions for setting up the necessary toolchains for the MicroPython for Tang Nano 4K project.
+
+## 1. ARM GNU Toolchain
+
+The MicroPython firmware for the Cortex-M3 is compiled using the ARM GNU Toolchain.
+
+### Recommended Version
+- **Version**: 10.3-2021.10
+- **Triple**: `arm-none-eabi-`
+
+### Installation (Ubuntu/Debian)
+```bash
+sudo apt update
+sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi gdb-arm-none-eabi libnewlib-arm-none-eabi
+```
+
+For the exact 10.3-2021.10 version, download from the [ARM Developer website](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) and add the `bin` directory to your `PATH`.
+
+---
+
+## 2. Open-Source FPGA Toolchain (Gowin)
+
+For an entirely open-source workflow, you can use **Project Apicula**, **Yosys**, and **nextpnr-himbaechel** to generate bitstreams for the Tang Nano 4K (GW1NSR-4C).
+
+### Prerequisites
+Ensure you have Python 3 and `pip` installed.
+
+### Installation Steps
+
+1.  **Project Apicula**: Provides the documentation and bitstream tools.
+    ```bash
+    pip install apycula
+    ```
+
+2.  **Yosys**: For Verilog synthesis.
+    ```bash
+    # Follow instructions at https://github.com/YosysHQ/yosys
+    sudo apt install yosys
+    ```
+
+3.  **nextpnr-himbaechel**: The place-and-route tool supporting Gowin devices.
+    ```bash
+    # Follow instructions at https://github.com/YosysHQ/nextpnr
+    # Ensure you build with -DARCH=gowin
+    ```
+
+### Usage Overview
+
+To generate a bitstream (`.fs`):
+
+1.  **Synthesis**:
+    ```bash
+    yosys -p "read_verilog top.v; synth_gowin -json top.json"
+    ```
+
+2.  **Place & Route**:
+    ```bash
+    nextpnr-himbaechel --json top.json \
+                       --write top_pnr.json \
+                       --device GW1NSR-LV4CQN48PC7/I6 \
+                       --vopt family=GW1NS-4 \
+                       --vopt cst=pins.cst
+    ```
+
+3.  **Pack**:
+    ```bash
+    gowin_pack -d GW1NS-4 -o bitstream.fs top_pnr.json
+    ```
+
+---
+
+## 3. Flashing Tools
+
+### openfpgaflasher
+The project uses `openfpgaflasher` for unified flashing of the FPGA bitstream and MCU firmware.
+
+```bash
+pip install openfpgaflasher
+```
+
+Usage:
+```bash
+openfpgaflasher -b bitstream.fs -m firmware_int.bin -e firmware_ext.bin
+```
+
+---
+
+## 4. Renode Simulation
+
+To run the integration tests, you need Renode installed.
+
+- **Installation**: Follow instructions at [renode.io](https://renode.io/).
+- **Robot Framework**:
+  ```bash
+  pip install robotframework==6.1 psutil pyyaml
+  ```


### PR DESCRIPTION
I have added a new documentation file `TOOLCHAIN_SETUP.md` that provides detailed instructions for setting up both the ARM GNU Toolchain and the open-source FPGA toolchain (Apycula, Yosys, nextpnr-himbaechel). I also updated the `HOWTO_TINY_TAPEOUT.md` guide to include an alternative bitstream generation path using these open-source tools, providing a complete non-proprietary workflow for Tiny Tapeout projects on the Tang Nano 4K. Finally, I ensured all documentation links are consistent and the project structure verification passes.

Fixes #310

---
*PR created automatically by Jules for task [5850674976915232310](https://jules.google.com/task/5850674976915232310) started by @chatelao*