### PR TITLE
Fix tt_echo diagram visibility

### DIFF
--- a/examples/tt_echo/README.md
+++ b/examples/tt_echo/README.md
@@ -4,7 +4,7 @@ This example demonstrates a minimal integration of a Tiny Tapeout (TT) module in
 
 ## End-to-End Integration Diagram
 
-![End-to-End Integration](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/micropython-tang-nano/main/examples/tt_echo/architecture.puml)
+![End-to-End Integration](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/chatelao/micropython-tang-nano/main/examples/tt_echo/architecture.puml)
 
 ## Example Files
 


### PR DESCRIPTION
The "End-to-End Integration Diagram" in the `tt_echo` example was not visible due to the use of an insecure `http` URL for the PlantUML proxy, which is blocked as mixed content on secure pages. Additionally, the `cache=no` parameter was causing intermittent 509 (Bandwidth Limit Exceeded) errors from the PlantUML service.

Changes:
- Updated the diagram URL in `examples/tt_echo/README.md` to use `https`.
- Removed `cache=no` from the URL parameters.
- Verified project structure and URL response.

Fixes #319

---
*PR created automatically by Jules for task [5174257131846223882](https://jules.google.com/task/5174257131846223882) started by @chatelao*