### PR TITLE
Adaptive Blink Example for Tang Nano 4K

### DIFF
--- a/examples/blink/blink.cst
+++ b/examples/blink/blink.cst
@@ -1,0 +1,11 @@
+// Physical Constraints for Adaptive Blink on Tang Nano 4K
+
+IO_LOC "clk_27m" 45;
+IO_LOC "led_pin" 10;
+IO_LOC "btn1_pin" 15;
+IO_LOC "btn2_pin" 14;
+
+IO_PORT "clk_27m"  IO_TYPE=LVCMOS33;
+IO_PORT "led_pin"  IO_TYPE=LVCMOS33;
+IO_PORT "btn1_pin" IO_TYPE=LVCMOS33;
+IO_PORT "btn2_pin" IO_TYPE=LVCMOS33;

--- a/examples/blink/blink.py
+++ b/examples/blink/blink.py
@@ -1,15 +1,33 @@
 import machine
 import time
 
+# Pin Mapping:
+# Pin 0 -> Internal GPIO 0 -> Physical Pin 10 (LED)
+# Pin 1 -> Internal GPIO 1 -> Physical Pin 15 (Button 1)
+# Pin 2 -> Internal GPIO 2 -> Physical Pin 14 (Button 2)
+
 led = machine.Pin(0, machine.Pin.OUT)
+btn1 = machine.Pin(1, machine.Pin.IN)
+btn2 = machine.Pin(2, machine.Pin.IN)
 
-print("Starting " + "blink test...")
-for i in range(5):
+print("Starting adaptive blink...")
+print("- Normal speed: No buttons pressed")
+print("- Fast speed: One button pressed")
+print("- Very fast speed: Both buttons pressed")
+
+while True:
+    # Buttons on Tang Nano 4K are active-low (0 when pressed)
+    b1_pressed = (btn1.value() == 0)
+    b2_pressed = (btn2.value() == 0)
+
+    if b1_pressed and b2_pressed:
+        delay = 50   # Very fast
+    elif b1_pressed or b2_pressed:
+        delay = 200  # Fast
+    else:
+        delay = 500  # Normal
+
     led.on()
-    print("LED " + "ON")
-    time.sleep_ms(500)
+    time.sleep_ms(delay)
     led.off()
-    print("LED " + "OFF")
-    time.sleep_ms(500)
-
-print("Blink " + "test complete.")
+    time.sleep_ms(delay)

--- a/examples/blink/blink_wrapper.v
+++ b/examples/blink/blink_wrapper.v
@@ -1,0 +1,39 @@
+/*
+ * FPGA Wrapper for Adaptive Blink on Tang Nano 4K
+ * Connects M3 GPIOs to physical LED and Buttons.
+ */
+
+`default_nettype none
+
+module blink_wrapper (
+    input  wire clk_27m,
+    output wire led_pin,   // Physical Pin 10
+    input  wire btn1_pin,  // Physical Pin 15
+    input  wire btn2_pin   // Physical Pin 14
+);
+
+    // M3 GPIO signals (standard naming for Gowin_EMPU_M3)
+    wire [15:0] m3_gpio_i;
+    wire [15:0] m3_gpio_o;
+    wire [15:0] m3_gpio_oe;
+
+    // --- GPIO Mapping ---
+    // GPIO[0] is mapped to the LED (Output)
+    assign led_pin = m3_gpio_o[0];
+
+    // GPIO[1] and GPIO[2] are mapped to the buttons (Input)
+    assign m3_gpio_i[0] = 1'b0;
+    assign m3_gpio_i[1] = btn1_pin;
+    assign m3_gpio_i[2] = btn2_pin;
+    assign m3_gpio_i[15:3] = 13'b0;
+
+    // --- M3 IP Core Instantiation ---
+    // This instantiates the Cortex-M3 hard core.
+    Gowin_EMPU_M3 m3_inst (
+        .GPIOI      (m3_gpio_i),
+        .GPIOO      (m3_gpio_o),
+        .GPIOOUTEN  (m3_gpio_oe),
+        .SYS_CLK    (clk_27m)
+    );
+
+endmodule


### PR DESCRIPTION
This PR implements an adaptive blink example for the Tang Nano 4K. 

Key changes:
1. **FPGA Wrapper (`blink_wrapper.v`)**: Instantiates the `Gowin_EMPU_M3` core and routes internal `GPIO[0]` to an external LED pin, and `GPIO[1:2]` to external button pins.
2. **Constraints (`blink.cst`)**: Maps the FPGA ports to physical Pins 10 (LED), 15 (Button 1), and 14 (Button 2).
3. **Python Script (`blink.py`)**: Uses the `machine.Pin` API to control the LED and poll the buttons. It implements a variable delay:
    - 500ms (Idle)
    - 200ms (One button pressed)
    - 50ms (Both buttons pressed)

This ensures the user can interact with the hardware buttons to change the MicroPython execution flow.

Fixes #317

---
*PR created automatically by Jules for task [15614847532596600975](https://jules.google.com/task/15614847532596600975) started by @chatelao*