### PR TITLE
Detailed M3 and FPGA IP Configuration Documentation

### DIFF
--- a/M3_FPGA_INTEGRATIONS.md
+++ b/M3_FPGA_INTEGRATIONS.md
@@ -2,6 +2,8 @@
 
 This document describes the communication interfaces between the ARM Cortex-M3 "Hard Core" and the FPGA fabric on the Sipeed Tang Nano 4K.
 
+![M3 Subsystem Architecture](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/chatelao/micropython-tang-nano/main/m3_subsystem.puml)
+
 ## 1. Overview
 
 The GW1NSR-4C provides several dedicated paths for the Cortex-M3 to interact with logic implemented in the FPGA:
@@ -29,15 +31,23 @@ In your top-level Verilog, the signals are typically mapped as follows:
 
 The APB2 bus is the primary method for register-mapped communication between the M3 and custom FPGA IPs. The SoC provides 12 dedicated "slots," each with a 256-byte address range.
 
-### How it works
+### 3.1 IP Core Configuration (Gowin EDA)
+To use the APB2 expansion, you must enable it in the **Gowin_EMPU_M3** IP core configuration:
+1.  **IP Generator**: Select `Gowin_EMPU_M3`.
+2.  **Configuration Tab**:
+    *   **Enable APB Expansion**: Set to `Enable`.
+    *   This will expose the `APB_PSEL`, `APB_PENABLE`, `APB_PADDR`, `APB_PWRITE`, `APB_PWDATA`, `APB_PRDATA`, and `APB_PREADY` ports on the M3 IP core.
+3.  **Address Decoding**: The M3 uses the `PSEL` signal to indicate which slot is being accessed. You must implement a simple decoder if using multiple slots, or use the provided `PSELx` signals if the IP core version supports individual slot selects.
+
+### 3.2 Slot Mapping
 Think of these slots as pre-allocated memory windows. When you implement a peripheral in the FPGA (e.g., a motor controller or a display driver), you can map its internal registers to one of these slots. From MicroPython, you can then interact with your hardware by reading/writing to the corresponding memory address.
 
-| Slot | Base Address | Default Usage in Examples |
-| :--- | :--- | :--- |
-| Slot 1 | `0x40002400` | **Tiny Tapeout (TT) Wrapper**: Logic control & I/O |
-| Slot 2 | `0x40002500` | **NEORV32 Bridge**: RISC-V co-processor control |
-| Slot 3 | `0x40002600` | **SERV Bridge**: Minimal RISC-V control |
-| Slots 4-12 | `0x40002700`+ | Available for custom User IPs |
+| Slot | Base Address | M3 Address Range | Default Usage in Examples |
+| :--- | :--- | :--- | :--- |
+| Slot 1 | `0x40002400` | `0x40002400 - 0x400024FF` | **Tiny Tapeout (TT) Wrapper** |
+| Slot 2 | `0x40002500` | `0x40002500 - 0x400025FF` | **NEORV32 Bridge** |
+| Slot 3 | `0x40002600` | `0x40002600 - 0x400026FF` | **SERV Bridge** |
+| Slots 4-12 | `0x40002700`+ | `0x40002700 - 0x40002FFF` | Available for custom User IPs |
 
 ### MicroPython Example
 ```python
@@ -50,7 +60,31 @@ val = machine.mem32[0x40002704]
 
 ## 4. AHB Expansion (XIP & PSRAM)
 
-The AHB bus is used for high-bandwidth peripherals.
+The AHB bus is used for high-bandwidth peripherals like PSRAM and External SPI Flash (XIP).
+
+### 4.1 PSRAM Memory Interface (AHB)
+To use the 8MB external PSRAM, instantiate the **PSRAM Memory Interface** IP:
+1.  **IP Generator**: Select `PSRAM Memory Interface`.
+2.  **Configuration**:
+    *   **Memory Model**: `W955D8MBYA` (for Tang Nano 4K).
+    *   **Memory Clock**: `166 MHz` (Max).
+    *   **DQ Width**: `16` (2CH mode is often used for full performance).
+    *   **Bus Interface**: `AHB` (required for M3 mapping at 0xA0000000).
+3.  **M3 Connection**: Enable **AHB Expansion** in the `Gowin_EMPU_M3` core and connect it to the PSRAM IP.
+
+### 4.2 External Flash Interface (XIP)
+To access the external flash at `0x60000000` for MicroPython code execution:
+1.  **IP Generator**: Select `SPI Flash Interface`.
+2.  **Configuration**:
+    *   **Protocol**: `Single SPI` (Standard).
+    *   **Bus Interface**: `AHB` (required for XIP).
+    *   **Memory Mapped**: Enable `Memory Mapped Mode`.
+    *   **Base Address**: Set to `0x60000000`.
+3.  **Pin Constraints**: Map the SPI signals to the following hardware pins:
+    *   `CS_N`: Pin 36
+    *   `SCLK`: Pin 37
+    *   `MOSI`: Pin 38
+    *   `MISO`: Pin 39
 
 | Range | Usage | IP Core Required |
 | :--- | :--- | :--- |

--- a/README.md
+++ b/README.md
@@ -90,19 +90,14 @@ Use a serial terminal with the following configuration:
 For detailed serial port instructions, see [SERIAL_PORT_ACCESS.md](SERIAL_PORT_ACCESS.md).
 
 ## IP Core Configuration (Gowin EDA)
-To access the external flash at `0x60000000`, you must instantiate the **SPI Flash Interface** IP in your Gowin project:
-1.  **IP Generator**: Select `SPI Flash Interface`.
-2.  **Configuration**:
-    *   **Protocol**: Single SPI (Standard).
-    *   **Bus Interface**: `AHB` (required for XIP).
-    *   **Memory Mapped**: Enable `Memory Mapped Mode`.
-    *   **Base Address**: Set to `0x60000000` in the AHB expansion configuration.
-3.  **M3 Connection**: Connect the IP core to the Cortex-M3 **AHB Master** port (typically via the AHB Expansion interface).
-4.  **Pin Constraints**: Map the SPI signals to the following pins:
-    *   `CS_N`: Pin 36
-    *   `SCLK`: Pin 37
-    *   `MOSI`: Pin 38
-    *   `MISO`: Pin 39
+Setting up the SoC subsystem on the Tang Nano 4K requires specific IP core configurations in Gowin EDA:
+
+- **Cortex-M3 (Gowin_EMPU_M3)**: Enable APB and AHB expansion to allow the M3 to communicate with logic and memory in the FPGA fabric.
+- **APB2 Expansion**: Each slot (256 bytes) is mapped starting at `0x40002400`.
+- **External PSRAM**: Requires the `PSRAM Memory Interface` IP (Model: W955D8MBYA) mapped to `0xA0000000`.
+- **External SPI Flash (XIP)**: Requires the `SPI Flash Interface` IP mapped to `0x60000000`.
+
+For step-by-step instructions and pin constraints, see the **[M3-FPGA Integration Guide](M3_FPGA_INTEGRATIONS.md#3-apb2-expansion-slots)**.
 
 ### Installation with Gowin Programmer
 1.  **Build** the firmware with `SPLIT_FLASH=1`.

--- a/m3_subsystem.puml
+++ b/m3_subsystem.puml
@@ -1,0 +1,34 @@
+@startuml m3_subsystem
+!include https://raw.githubusercontent.com/plantuml-office/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_LEFT_RIGHT()
+
+title M3-FPGA Subsystem Architecture (Tang Nano 4K)
+
+Container_Boundary(soc, "GW1NSR-4C SoC") {
+    Component(m3, "Cortex-M3 Hard Core", "ARMv7-M", "Gowin_EMPU_M3 IP")
+
+    Boundary(fabric, "FPGA Fabric") {
+        Component(apb_slots, "APB2 Slots (0x40002400)", "Register-mapped", "Slot 1-12")
+        Component(psram_ctrl, "PSRAM Controller", "AHB (0xA0000000)", "W955D8MBYA (8MB)")
+        Component(flash_ctrl, "SPI Flash Interface", "AHB (0x60000000)", "XIP (4MB)")
+
+        Rel(m3, apb_slots, "APB2 Expansion")
+        Rel(m3, psram_ctrl, "AHB Expansion")
+        Rel(m3, flash_ctrl, "AHB Expansion")
+    }
+
+    Component(int_flash, "Internal Flash (32KB)", "0x00000000", "Bootloader & Vectors")
+    Component(int_sram, "Internal SRAM (22KB)", "0x20000000", "Stack & Fast Heap")
+
+    Rel(m3, int_flash, "I-Code/D-Code")
+    Rel(m3, int_sram, "System Bus")
+}
+
+Component_Ext(ext_psram, "External PSRAM", "Physical Chip", "8MB 166MHz")
+Component_Ext(ext_flash, "External SPI Flash", "Physical Chip", "4MB MicroPython FS")
+
+Rel(psram_ctrl, ext_psram, "DQ[15:0], SCLK, CS#")
+Rel(flash_ctrl, ext_flash, "MOSI, MISO, SCLK, CS# (Pins 36-39)")
+
+@enduml

--- a/test/verify_structure.py
+++ b/test/verify_structure.py
@@ -28,6 +28,7 @@ def test_structure():
         'HOWTO_TINY_TAPEOUT.md',
         'M3_FPGA_INTEGRATIONS.md',
         'M3_MICROPYTHON.md',
+        'm3_subsystem.puml',
         'AUDIT.md',
         'COMPLIANCE_TESTS.md',
         'SERIAL_PORT_ACCESS.md',


### PR DESCRIPTION
This update provides comprehensive documentation for setting up the core SoC components on the Sipeed Tang Nano 4K using Gowin EDA. It includes precise IP generator settings for the Cortex-M3, PSRAM, and External Flash, along with a new architectural diagram to assist with hardware-level integration.

Fixes #336

---
*PR created automatically by Jules for task [11469948291543426850](https://jules.google.com/task/11469948291543426850) started by @chatelao*