### PR TITLE
Tidy up README.md with tables and English translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,34 @@ This project aims to port MicroPython to the "Sipeed Tang Nano 4K" FPGA developm
 For a comprehensive overview of the port, including hardware details, installation, and usage, see the [Tang Nano 4K MicroPython Port Guide](M3_MICROPYTHON.md).
 
 ## Supported MicroPython Features
-- **Core Modules**: `machine`, `time`/`utime`, `uos`, `io`.
-- **Machine Module Peripherals**:
-    - `Pin`: GPIO control (0-15) with hardware interrupt support.
-    - `Timer`: Hardware timers for periodic or one-shot events.
-    - `PWM`: Hardware-based Pulse Width Modulation.
-    - `ADC`: 12-bit Analog-to-Digital Converter.
-    - `I2C` / `SoftI2C`: Hardware and software I2C Master support.
-    - `SPI` / `SoftSPI`: Hardware and software SPI Master support.
-    - `RTC`: Real-Time Clock for date and time management.
-    - `WDT`: Hardware Watchdog Timer.
-    - `FPGABridge`: Low-level access to the 16-bit M3-to-FPGA GPIO bridge (See [FPGA_BRIDGE_USAGE.md](FPGA_BRIDGE_USAGE.md)).
-    - `NEORV32`: Integration example for the NEORV32 RISC-V co-processor (See `examples/cpus/neorv32/`).
-    - `SERV RISC-V`: Example of running a RISC-V core in the FPGA fabric (See `examples/cpus/serv_riscv/`).
-    - `Flash`: Block device interface for the onboard SPI Flash.
-- **Filesystem**: LittleFS (LFS2) on external SPI Flash.
-- **Runtime**: Garbage Collector, REPL over UART0.
+
+| Module / Feature | Description |
+| :--- | :--- |
+| **Core Modules** | `machine`, `time`/`utime`, `uos`, `io` |
+| **Pin** | GPIO control (0-15) with hardware interrupt support |
+| **Timer** | Hardware timers for periodic or one-shot events |
+| **PWM** | Hardware-based Pulse Width Modulation |
+| **ADC** | 12-bit Analog-to-Digital Converter |
+| **I2C / SoftI2C** | Hardware and software I2C Master support |
+| **SPI / SoftSPI** | Hardware and software SPI Master support |
+| **RTC** | Real-Time Clock for date and time management |
+| **WDT** | Hardware Watchdog Timer |
+| **FPGABridge** | Low-level access to the 16-bit M3-to-FPGA GPIO bridge (See [FPGA_BRIDGE_USAGE.md](FPGA_BRIDGE_USAGE.md)) |
+| **NEORV32** | Integration example for the NEORV32 RISC-V co-processor (See `examples/cpus/neorv32/`) |
+| **SERV RISC-V** | Example of running a RISC-V core in the FPGA fabric (See `examples/cpus/serv_riscv/`) |
+| **Flash** | Block device interface for the onboard SPI Flash |
+| **Filesystem** | LittleFS (LFS2) on external SPI Flash |
+| **Runtime** | Garbage Collector, REPL over UART0 |
 
 ## Unsupported Features
-- **Floating-point**: No hardware or software floating-point support (`MICROPY_PY_BUILTINS_FLOAT=0`).
-- **Math Module**: The `math` module is disabled to save flash space.
-- **Asynchronous**: `asyncio` and `async`/`await` are currently not supported.
-- **Connectivity**: No built-in network or Bluetooth stacks.
-- **Big Integers**: Support for arbitrary-precision integers is disabled.
+
+| Feature | Status / Reason |
+| :--- | :--- |
+| **Floating-point** | No hardware or software support (`MICROPY_PY_BUILTINS_FLOAT=0`) |
+| **Math Module** | Disabled to save flash space |
+| **Asynchronous** | `asyncio` and `async`/`await` are currently not supported |
+| **Connectivity** | No built-in network or Bluetooth stacks |
+| **Big Integers** | Arbitrary-precision integer support is disabled |
 
 ## Memory Layout
 
@@ -47,74 +52,87 @@ For a comprehensive overview of the port, including hardware details, installati
 
 ### Component Locations in Memory
 
-- **MicroPython Part 1 (Internal)**: Located at `0x00000000`. Contains the essential boot code and interrupt vectors required for the Cortex-M3 to start.
-- **MicroPython Part 2 (External)**: Located at `0x60000000`. This is the bulk of the MicroPython runtime, including the bytecode interpreter and frozen modules, accessed via memory-mapped SPI Flash.
-- **APB2 (FPGA Peripherals)**: The memory region from `0x40002400` to `0x40002FFF` is reserved for peripherals implemented in the FPGA fabric (12 slots of 256 bytes each).
-- **SPI Flash Access**: The external SPI flash is memory-mapped to `0x60000000` via the AHB Expansion interface, allowing Execute-In-Place (XIP) functionality.
-- **Tiny Tapeout Wrapper**: Mapped to **APB2 Slot 1** (`0x40002400`). It provides the bridge between the Cortex-M3 and the Tiny Tapeout module pins.
-- **Tiny Tapeout Logic**: The actual user logic (TT project) is controlled via the `DATA` (`0x40002400`) and `CTRL` (`0x4000240C`) registers within the wrapper.
+| Component | Location / Address | Description |
+| :--- | :--- | :--- |
+| **MicroPython Part 1** | `0x00000000` | Essential boot code and interrupt vectors (Internal Flash) |
+| **MicroPython Part 2** | `0x60000000` | Bulk of MicroPython runtime, bytecode interpreter, and frozen modules (External SPI Flash XIP) |
+| **APB2 Peripherals** | `0x40002400` - `0x40002FFF` | Peripherals implemented in the FPGA fabric (12 slots of 256 bytes each) |
+| **SPI Flash Access** | `0x60000000` | Memory-mapped AHB Expansion interface for Execute-In-Place (XIP) |
+| **Tiny Tapeout Wrapper** | **APB2 Slot 1** (`0x40002400`) | Bridge between the Cortex-M3 and Tiny Tapeout module pins |
+| **Tiny Tapeout Logic** | `0x40002400` / `0x4000240C` | User logic control via `DATA` and `CTRL` registers |
 
 ## Project Structure
-- `/definitions` - Datasheets and Standards to be used.
-- `/examples` - Example MicroPython scripts and FPGA projects.
-- `/src` - Source files for the MicroPython port.
-- `/test` - Unit, System, and End-2-End test concepts and cases.
-- `/.github` - Workflows for CI/CD.
-- `AUDIT.md` - Comprehensive project audit report.
-- `COMPLIANCE_TESTS.md` - MicroPython compliance testing results.
-- `FPGA_BRIDGE_USAGE.md` - Detailed guide on using MicroPython to interact with the FPGA.
-- `GEMINI.md` - Project goal and structural guidelines.
-- `HOWTO_TINY_TAPEOUT.md` - Guide to loading and testing Tiny Tapeout modules.
-- `M3_FPGA_INTEGRATIONS.md` - Guide to communication interfaces between M3 and FPGA.
-- `M3_MICROPYTHON.md` - Supported MicroPython features and port guide.
-- `ROADMAP.md` - Progress tracking and future steps.
-- `SERIAL_PORT_ACCESS.md` - Guide to accessing the Cortex-M3 serial port.
-- [`TOOLCHAIN_SETUP.md`](TOOLCHAIN_SETUP.md) - Instructions for setting up the ARM and FPGA toolchains.
+
+| Path | Description |
+| :--- | :--- |
+| `/definitions` | Datasheets and Standards to be used |
+| `/examples` | Example MicroPython scripts and FPGA projects |
+| `/src` | Source files for the MicroPython port |
+| `/test` | Unit, System, and End-2-End test concepts and cases |
+| `/.github` | Workflows for CI/CD |
+| `AUDIT.md` | Comprehensive project audit report |
+| `COMPLIANCE_TESTS.md` | MicroPython compliance testing results |
+| `FPGA_BRIDGE_USAGE.md` | Guide on using MicroPython to interact with the FPGA |
+| `GEMINI.md` | Project goal and structural guidelines |
+| `HOWTO_TINY_TAPEOUT.md` | Guide to loading and testing Tiny Tapeout modules |
+| `M3_FPGA_INTEGRATIONS.md` | Guide to communication interfaces between M3 and FPGA |
+| `M3_MICROPYTHON.md` | Supported MicroPython features and port guide |
+| `ROADMAP.md` | Progress tracking and future steps |
+| `SERIAL_PORT_ACCESS.md` | Guide to accessing the Cortex-M3 serial port |
+| [`TOOLCHAIN_SETUP.md`](TOOLCHAIN_SETUP.md) | Instructions for setting up the toolchains |
 
 ## UART Configuration
 The MicroPython REPL is accessible via the Cortex-M3 UART0 peripheral.
 
 ### Hardware Wiring
-The UART0 signals are routed through the FPGA fabric to the following pins:
-- **UART0 RX**: FPGA Pin 19 (IOB13B)
-- **UART0 TX**: FPGA Pin 18 (IOB13A)
+
+| Signal | FPGA Pin | Description |
+| :--- | :--- | :--- |
+| **UART0 RX** | 19 (IOB13B) | Receive data input |
+| **UART0 TX** | 18 (IOB13A) | Transmit data output |
 
 ### Terminal Settings
-Use a serial terminal with the following configuration:
-- **Baud Rate**: 115200
-- **Data Bits**: 8
-- **Parity**: None
-- **Stop Bits**: 1
-- **Flow Control**: None (8N1)
+
+| Parameter | Value |
+| :--- | :--- |
+| **Baud Rate** | 115200 |
+| **Data Bits** | 8 |
+| **Parity** | None |
+| **Stop Bits** | 1 |
+| **Flow Control** | None (8N1) |
 
 For detailed serial port instructions, see [SERIAL_PORT_ACCESS.md](SERIAL_PORT_ACCESS.md).
 
-## Pinbelegung Tang Nano 4K
+## Pinout Tang Nano 4K
 
-### Onboard-Peripherie
-| Komponente | Pin | Bank | Logik |
+### Onboard Peripherals
+
+| Component | Pin | Bank | Logic |
 | :--- | :--- | :--- | :--- |
-| **LED** | 10 | 0 | Low-aktiv |
-| **Taste 1 (S1)** | 15 | 3 | High-aktiv |
-| **Taste 2 (S2)** | 14 | 3 | High-aktiv |
-| **System-Takt** | 45 | 1 | 27 MHz Quarz |
+| **LED** | 10 | 0 | Active-low |
+| **Button 1 (S1)** | 15 | 3 | Active-high |
+| **Button 2 (S2)** | 14 | 3 | Active-high |
+| **System Clock** | 45 | 1 | 27 MHz Crystal |
 
-### HDMI-Schnittstelle (TMDS)
+### HDMI Interface (TMDS)
+
 | Signal | Pin (+) | Pin (-) | Bank |
 | :--- | :--- | :--- | :--- |
-| **TMDS Lane 0** (Blau) | 30 | 29 | 2 |
-| **TMDS Lane 1** (Grün) | 32 | 31 | 2 |
-| **TMDS Lane 2** (Rot) | 35 | 34 | 2 |
-| **TMDS Takt** | 28 | 27 | 2 |
+| **TMDS Lane 0** (Blue) | 30 | 29 | 2 |
+| **TMDS Lane 1** (Green) | 32 | 31 | 2 |
+| **TMDS Lane 2** (Red) | 35 | 34 | 2 |
+| **TMDS Clock** | 28 | 27 | 2 |
 
-### System & Programmierung
-| Funktion | Pins | Bank | Beschreibung |
+### System & Programming
+
+| Function | Pins | Bank | Description |
 | :--- | :--- | :--- | :--- |
 | **JTAG** | 3, 4, 6, 7, 8 | 0 | TDI, TDO, TMS, TCK, JTAGSEL_N |
 | **SPI Flash** | 1, 2, 47, 48 | 0/1 | MCLK, MCS, MISO, MOSI |
-| **UART0 (REPL)** | 18 (TX), 19 (RX) | 3 | Debug-Konsole |
+| **UART0 (REPL)** | 18 (TX), 19 (RX) | 3 | Debug Console |
 
-### Freie Pins auf den Header-Leisten
+### Available Header Pins
+
 | Bank | Pins |
 | :--- | :--- |
 | **Bank 0** | 9 (DONE) |
@@ -122,30 +140,29 @@ For detailed serial port instructions, see [SERIAL_PORT_ACCESS.md](SERIAL_PORT_A
 | **Bank 2** | 33 |
 | **Bank 3** | 13, 16, 17, 20, 21, 22, 23 |
 
-*Hinweis: Die Pins für JTAG und Flash sollten für allgemeine Zwecke vermieden werden, um die Programmierbarkeit nicht zu beeinträchtigen.*
+*Note: JTAG and Flash pins should be avoided for general use to maintain programmability.*
 
 ## IP Core Configuration (Gowin EDA)
+
 Setting up the SoC subsystem on the Tang Nano 4K requires specific IP core configurations in Gowin EDA:
 
-- **Cortex-M3 (Gowin_EMPU_M3)**: Enable APB and AHB expansion to allow the M3 to communicate with logic and memory in the FPGA fabric.
-- **APB2 Expansion**: Each slot (256 bytes) is mapped starting at `0x40002400`.
-- **External PSRAM**: Requires the `PSRAM Memory Interface` IP (Model: W955D8MBYA) mapped to `0xA0000000`.
-- **External SPI Flash (XIP)**: Requires the `SPI Flash Interface` IP mapped to `0x60000000`.
+| Feature / IP Core | Configuration / Notes |
+| :--- | :--- |
+| **Cortex-M3 (Gowin_EMPU_M3)** | Enable APB and AHB expansion to allow the M3 to communicate with logic and memory in the FPGA fabric |
+| **APB2 Expansion** | Each slot (256 bytes) is mapped starting at `0x40002400` |
+| **External PSRAM** | Requires the `PSRAM Memory Interface` IP (Model: W955D8MBYA) mapped to `0xA0000000` |
+| **External SPI Flash (XIP)** | Requires the `SPI Flash Interface` IP mapped to `0x60000000` |
 
 For step-by-step instructions and pin constraints, see the **[M3-FPGA Integration Guide](M3_FPGA_INTEGRATIONS.md#3-apb2-expansion-slots)**.
 
 ### Installation with Gowin Programmer
-1.  **Build** the firmware with `SPLIT_FLASH=1`.
-2.  **Flash FPGA Bitstream**: Flash your `.fs` file containing the SPI Flash Interface IP.
-3.  **Flash Internal Flash**:
-    *   Access Mode: `MCU Mode`
-    *   Operation: `Flash Erase, Program, Verify`
-    *   File: `build/firmware_int.bin`
-4.  **Flash External Flash**:
-    *   Access Mode: `External Flash Mode`
-    *   Operation: `exFlash Erase, Program, Verify`
-    *   File: `build/firmware_ext.bin`
-    *   Address: `0x000000` (The M3 sees this at `0x60000000`)
+
+| Step | Description | Details / Parameters |
+| :--- | :--- | :--- |
+| 1 | **Build** | Compile firmware with `SPLIT_FLASH=1` |
+| 2 | **Flash FPGA Bitstream** | Flash the `.fs` file containing the SPI Flash Interface IP |
+| 3 | **Flash Internal Flash** | Access Mode: `MCU Mode`<br>Operation: `Flash Erase, Program, Verify`<br>File: `build/firmware_int.bin` |
+| 4 | **Flash External Flash** | Access Mode: `External Flash Mode`<br>Operation: `exFlash Erase, Program, Verify`<br>File: `build/firmware_ext.bin`<br>Address: `0x000000` (Mapped to `0x60000000`) |
 
 For more details on M3-FPGA integration, see [M3_FPGA_INTEGRATIONS.md](M3_FPGA_INTEGRATIONS.md).
 


### PR DESCRIPTION
This change refactors the project's root `README.md` file to use Markdown tables for technical specifications and lists, making the information easier to scan. It also translates the previously German "Pinout" section and its associated tables into English.

Key improvements:
- Converted feature lists, project structure, memory layout, and configuration steps into structured tables.
- Standardized the entire document to English by translating the Pinout section.
- Improved formatting and clarity of the installation instructions.
- Verified structural compliance with `test/verify_structure.py`.

Fixes #343

---
*PR created automatically by Jules for task [15680254424858146667](https://jules.google.com/task/15680254424858146667) started by @chatelao*