### PR TITLE
Refactor PSRAM memory logic in m3_ext_psgram example

### DIFF
--- a/examples/m3_baremetal/m3_ext_psgram/Makefile
+++ b/examples/m3_baremetal/m3_ext_psgram/Makefile
@@ -28,8 +28,8 @@ firmware.bin: firmware.elf
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-bitstream.fs: top.v top.cst
-	$(YOSYS) -p "synth_gowin -top top -json top.json" top.v
+bitstream.fs: top.v psram_memory.v top.cst
+	$(YOSYS) -p "synth_gowin -top top -json top.json" top.v psram_memory.v
 	$(NEXTPNR) --device GW1NSR-LV4CQN48PC7/I6 --family GW1NS-4 --json top.json --write top_pnr.json --vopt family=GW1NS-4 --vopt device=GW1NSR-4C --cst top.cst
 	$(GOWIN_PACK) -d GW1NS-4 top_pnr.json $@
 

--- a/examples/m3_baremetal/m3_ext_psgram/psram_memory.v
+++ b/examples/m3_baremetal/m3_ext_psgram/psram_memory.v
@@ -1,0 +1,62 @@
+/* psram_memory.v - m3_ext_psgram */
+`default_nettype none
+
+module psram_memory (
+    input  wire        clk,
+    input  wire [31:0] haddr,
+    input  wire [31:0] hwdata,
+    output wire [31:0] hrdata,
+    input  wire        hwrite,
+    input  wire [1:0]  htrans,
+    output wire        hready
+);
+
+    // AHB Address Decoding (PSRAM: 0xA0000000)
+    wire ahb_hsel_psram = (haddr[31:28] == 4'hA);
+
+    wire [31:0] psram_rdata;
+    wire        psram_ready;
+
+    // AHB Data Phase Multiplexing
+    assign hrdata = psram_rdata;
+    assign hready = ahb_hsel_psram ? psram_ready : 1'b1;
+
+    // --- PSRAM Memory Interface (AHB Bridge) ---
+    // Note: For a real device, you'd use the Gowin PSRAM Controller IP.
+    PSRAM_Memory_Interface psram_inst (
+        .hclk        (clk),
+        .hsel        (ahb_hsel_psram),
+        .haddr       (haddr),
+        .hwrite      (hwrite),
+        .htrans      (htrans),
+        .hwdata      (hwdata),
+        .hrdata      (psram_rdata),
+        .hready      (psram_ready)
+    );
+
+endmodule
+
+// This would typically be a Gowin IP core.
+module PSRAM_Memory_Interface (
+    input  wire        hclk,
+    input  wire        hsel,
+    input  wire [31:0] haddr,
+    input  wire        hwrite,
+    input  wire [1:0]  htrans,
+    input  wire [31:0] hwdata,
+    output wire [31:0] hrdata,
+    output wire        hready
+);
+    // Simple AHB-Lite PSRAM Emulator
+    reg [31:0] ram [0:255]; // Tiny RAM for testing
+    wire [7:0] index = haddr[9:2];
+
+    always @(posedge hclk) begin
+        if (hsel && hwrite && htrans[1]) begin
+            ram[index] <= hwdata;
+        end
+    end
+
+    assign hrdata = ram[index];
+    assign hready = 1'b1;
+endmodule

--- a/examples/m3_baremetal/m3_ext_psgram/top.v
+++ b/examples/m3_baremetal/m3_ext_psgram/top.v
@@ -13,17 +13,6 @@ module top (
     wire        ahb_write;
     wire [1:0]  ahb_trans;
     wire        ahb_ready;
-    wire        ahb_hsel_psram;
-
-    // AHB Address Decoding (PSRAM: 0xA0000000)
-    assign ahb_hsel_psram = (ahb_addr[31:28] == 4'hA);
-
-    wire [31:0] psram_rdata;
-    wire        psram_ready;
-
-    // AHB Data Phase Multiplexing
-    assign ahb_rdata = psram_rdata;
-    assign ahb_ready = ahb_hsel_psram ? psram_ready : 1'b1;
 
     // GPIO
     wire [15:0] m3_gpio_o;
@@ -45,42 +34,15 @@ module top (
         .GPIOO       (m3_gpio_o)
     );
 
-    // --- PSRAM Memory Interface (AHB Bridge) ---
-    // Note: For a real device, you'd use the Gowin PSRAM Controller IP.
-    PSRAM_Memory_Interface psram_inst (
-        .hclk        (clk_27m),
-        .hsel        (ahb_hsel_psram),
+    // --- PSRAM Memory Subsystem ---
+    psram_memory psram_subsystem_inst (
+        .clk         (clk_27m),
         .haddr       (ahb_addr),
+        .hwdata      (ahb_wdata),
+        .hrdata      (ahb_rdata),
         .hwrite      (ahb_write),
         .htrans      (ahb_trans),
-        .hwdata      (ahb_wdata),
-        .hrdata      (psram_rdata),
-        .hready      (psram_ready)
+        .hready      (ahb_ready)
     );
 
-endmodule
-
-// This would typically be a Gowin IP core.
-module PSRAM_Memory_Interface (
-    input  wire        hclk,
-    input  wire        hsel,
-    input  wire [31:0] haddr,
-    input  wire        hwrite,
-    input  wire [1:0]  htrans,
-    input  wire [31:0] hwdata,
-    output wire [31:0] hrdata,
-    output wire        hready
-);
-    // Simple AHB-Lite PSRAM Emulator
-    reg [31:0] ram [0:255]; // Tiny RAM for testing
-    wire [7:0] index = haddr[9:2];
-
-    always @(posedge hclk) begin
-        if (hsel && hwrite && htrans[1]) begin
-            ram[index] <= hwdata;
-        end
-    end
-
-    assign hrdata = ram[index];
-    assign hready = 1'b1;
 endmodule


### PR DESCRIPTION
Moved all PSRAM-related logic (AHB-Lite interface, address decoding for 0xA0000000, and the memory emulator) from the top-level Verilog file to a new subfile `psram_memory.v` in the `m3_ext_psgram` bare-metal example. Updated the top-level module and Makefile accordingly.

Fixes #358

---
*PR created automatically by Jules for task [5018132269258313437](https://jules.google.com/task/5018132269258313437) started by @chatelao*