### PR TITLE
Add documentation to m3_baremetal examples

### DIFF
--- a/examples/m3_baremetal/m3_blink_led_btn2/README.md
+++ b/examples/m3_baremetal/m3_blink_led_btn2/README.md
@@ -1,0 +1,26 @@
+# M3 Blink LED Button Example
+
+This example demonstrates basic GPIO interaction with the Cortex-M3 hard core on the Tang Nano 4K. It blinks the onboard LED (GPIO0) and changes the blink rate based on the state of Button S1 (GPIO1) and Button S2 (GPIO2).
+
+## Hardware Mapping
+
+| Peripheral | Pin | GPIO | Polarity |
+| :--- | :--- | :--- | :--- |
+| LED | 10 | GPIO0 | Active-High |
+| Button S1 | 15 | GPIO1 | Active-Low |
+| Button S2 | 14 | GPIO2 | Active-Low |
+
+## Documentation
+
+The following technical documents are available in the `../docs/` folder for reference:
+
+| Document | Description |
+| :--- | :--- |
+| [IPUG931-2.1E_Gowin_EMPU(GW1NS-4C) Software Programming Reference Manual.pdf](../docs/IPUG931-2.1E_Gowin_EMPU(GW1NS-4C)%20Software%20Programming%20Reference%20Manual.pdf) | Primary reference for M3 register mapping and SoC peripherals. |
+| [GW1NSR_DATASHEET_DS861E.pdf](../docs/GW1NSR_DATASHEET_DS861E.pdf) | Hardware datasheet for the GW1NSR-4C SoC. |
+| [IPUG944E.pdf](../docs/IPUG944E.pdf) | IP guide EMPU M3 core. |
+| [Tang Nano 4K - Sipeed Wiki.pdf](../docs/Tang%20Nano%204K%20-%20Sipeed%20Wiki.pdf) | Board-level overview and pinout from Sipeed. |
+
+## How to Build
+
+Run `make` in this directory to generate the bitstream and firmware.

--- a/examples/m3_baremetal/m3_ext_flash_boot/README.md
+++ b/examples/m3_baremetal/m3_ext_flash_boot/README.md
@@ -1,0 +1,18 @@
+# M3 External Flash Boot Example
+
+This example demonstrates how to configure the Cortex-M3 on the Tang Nano 4K to boot from external SPI Flash. This uses the XIP (eXecute In Place) feature, mapping the flash memory to the 0x60000000 address range.
+
+## Documentation
+
+The following technical documents are available in the `../docs/` folder for reference:
+
+| Document | Description |
+| :--- | :--- |
+| [IPUG1015-1.1E_Gowin SPI Flash Interface (With External Flash) IP User Guide.pdf](../docs/IPUG1015-1.1E_Gowin%20SPI%20Flash%20Interface%20(With%20External%20Flash)%20IP%20User%20Guide.pdf) | IP guide for AHB-mapped SPI Flash (XIP) controller. |
+| [IPUG931-2.1E_Gowin_EMPU(GW1NS-4C) Software Programming Reference Manual.pdf](../docs/IPUG931-2.1E_Gowin_EMPU(GW1NS-4C)%20Software%20Programming%20Reference%20Manual.pdf) | Primary reference for M3 register mapping and SoC peripherals. |
+| [GW1NSR_DATASHEET_DS861E.pdf](../docs/GW1NSR_DATASHEET_DS861E.pdf) | Hardware datasheet for the GW1NSR-4C SoC. |
+| [IPUG944E.pdf](../docs/IPUG944E.pdf) | IP guide EMPU M3 core. |
+
+## How to Build
+
+Run `make` in this directory to generate the bitstream and firmware.

--- a/examples/m3_baremetal/m3_ext_psgram/README.md
+++ b/examples/m3_baremetal/m3_ext_psgram/README.md
@@ -1,0 +1,22 @@
+# M3 External PSRAM Example
+
+This example demonstrates how to initialize and use the external 8MB PSRAM (Pseudo-SRAM) on the Sipeed Tang Nano 4K (GW1NSR-4C) SoC. The PSRAM is mapped at 0xA0000000.
+
+## Memory Mapping
+
+- **PSRAM Range**: `0xA0000000` to `0xA07FFFFF` (8MB)
+
+## Documentation
+
+The following technical documents are available in the `../docs/` folder for reference:
+
+| Document | Description |
+| :--- | :--- |
+| [IPUG525E-PSRAM-User-Guide.pdf](../docs/IPUG525E-PSRAM-User-Guide.pdf) | IP guide for Gowin PSRAM core. |
+| [IPUG931-2.1E_Gowin_EMPU(GW1NS-4C) Software Programming Reference Manual.pdf](../docs/IPUG931-2.1E_Gowin_EMPU(GW1NS-4C)%20Software%20Programming%20Reference%20Manual.pdf) | Primary reference for M3 register mapping and SoC peripherals. |
+| [GW1NSR_DATASHEET_DS861E.pdf](../docs/GW1NSR_DATASHEET_DS861E.pdf) | Hardware datasheet for the GW1NSR-4C SoC. |
+| [IPUG944E.pdf](../docs/IPUG944E.pdf) | IP guide EMPU M3 core. |
+
+## How to Build
+
+Run `make` in this directory to generate the bitstream and firmware.


### PR DESCRIPTION
Added missing documentation for the Cortex-M3 baremetal examples. Each example now has a README.md explaining its purpose, hardware configuration, and providing links to the relevant technical manuals in the central docs directory. This approach provides the requested documentation while maintaining repository health by avoiding binary file duplication.

Fixes #357

---
*PR created automatically by Jules for task [16677459051434818484](https://jules.google.com/task/16677459051434818484) started by @chatelao*