### PR TITLE
Add M3 External Flash Signal Documentation

### DIFF
--- a/examples/m3_baremetal/m3_ext_flash_boot/README.md
+++ b/examples/m3_baremetal/m3_ext_flash_boot/README.md
@@ -4,6 +4,12 @@ This example demonstrates how to configure the Cortex-M3 on the Tang Nano 4K to 
 
 ## Documentation
 
+### Architecture & Signals
+
+![M3 to External Flash XIP](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/chatelao/micropython-tang-nano/main/examples/m3_baremetal/m3_ext_flash_boot/docs/flash_xip_signals.puml)
+
+### Technical Reference
+
 The following technical documents are available for reference:
 
 | Document | Description | Location |

--- a/examples/m3_baremetal/m3_ext_flash_boot/docs/flash_xip_signals.puml
+++ b/examples/m3_baremetal/m3_ext_flash_boot/docs/flash_xip_signals.puml
@@ -1,0 +1,27 @@
+@startuml flash_xip_signals
+!include https://raw.githubusercontent.com/plantuml-office/C4-PlantUML/master/C4_Component.puml
+
+title M3 to External Flash (XIP) Signal Path
+
+Container_Boundary(fpga, "Tang Nano 4K (FPGA)") {
+    Component(m3, "Cortex-M3 Hard Core", "AHB-Lite Master")
+
+    Boundary(logic, "FPGA Fabric") {
+        Component(decoder, "Address Decoder", "Combinational", "HSEL if HADDR[31:28] == 0x6")
+        Component(flash_ctrl, "SPI Flash Interface IP", "AHB-Lite Slave", "Gowin IP Core")
+
+        Rel(m3, decoder, "HADDR[31:28]")
+        Rel(m3, flash_ctrl, "HADDR, HWDATA, HWRITE, HTRANS")
+        Rel(decoder, flash_ctrl, "HSEL_FLASH")
+        Rel(flash_ctrl, m3, "HRDATA, HREADY")
+    }
+}
+
+Component_Ext(ext_flash, "External SPI Flash", "Physical Chip", "4MB XIP")
+
+Rel(flash_ctrl, ext_flash, "flash_cs_n (Pin 36)")
+Rel(flash_ctrl, ext_flash, "flash_sclk (Pin 37)")
+Rel(flash_ctrl, ext_flash, "flash_mosi (Pin 38)")
+Rel(ext_flash, flash_ctrl, "flash_miso (Pin 39)")
+
+@enduml


### PR DESCRIPTION
This change adds architectural documentation for the M3 External Flash Boot example. It includes a new PlantUML diagram that illustrates the signal path between the Cortex-M3 hard core and the external SPI flash, specifically highlighting the AHB-Lite expansion bus signals and the physical pin connections on the Tang Nano 4K. The diagram is embedded into the example's README.md using the PlantUML proxy.

Fixes #369

---
*PR created automatically by Jules for task [2153382533820402328](https://jules.google.com/task/2153382533820402328) started by @chatelao*