### PR TITLE
Enhance PSRAM example documentation with architecture diagram and memory map

### DIFF
--- a/examples/m3_baremetal/m3_ext_psgram/README.md
+++ b/examples/m3_baremetal/m3_ext_psgram/README.md
@@ -2,9 +2,22 @@
 
 This example demonstrates how to initialize and use the external 8MB PSRAM (Pseudo-SRAM) on the Sipeed Tang Nano 4K (GW1NSR-4C) SoC. The PSRAM is mapped at 0xA0000000.
 
+## Architecture
+
+The diagram below illustrates the integration of the Cortex-M3 hard core with the FPGA fabric and the external PSRAM via the AHB-Lite expansion bus.
+
+![PSRAM Architecture](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/chatelao/micropython-tang-nano/main/examples/m3_baremetal/m3_ext_psgram/architecture.puml)
+
 ## Memory Mapping
 
-- **PSRAM Range**: `0xA0000000` to `0xA07FFFFF` (8MB)
+The following table details the memory-mapped regions for the PSRAM example:
+
+| Region | Start Address | End Address | Size | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **Internal Flash** | `0x00000000` | `0x00007FFF` | 32KB | Bootloader and Vector Table |
+| **Internal SRAM** | `0x20000000` | `0x200057FF` | 22KB | Stack and Fast Heap |
+| **External Flash** | `0x60000000` | `0x603FFFFF` | 4MB | XIP (Execute-in-Place) Storage |
+| **External PSRAM** | `0xA0000000` | `0xA07FFFFF` | 8MB | Primary Extended Heap |
 
 ## Documentation
 

--- a/examples/m3_baremetal/m3_ext_psgram/architecture.puml
+++ b/examples/m3_baremetal/m3_ext_psgram/architecture.puml
@@ -1,0 +1,24 @@
+@startuml architecture
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+title AHB-Lite External PSRAM Architecture (Tang Nano 4K)
+
+Container_Boundary(soc, "GW1NSR-4C SoC") {
+    Component(m3, "Cortex-M3 Hard Core", "ARMv7-M", "Gowin_EMPU_M3 IP")
+
+    Container_Boundary(fabric, "FPGA Fabric") {
+        Component(psram_sub, "PSRAM Memory Subsystem", "Verilog (psram_memory.v)", "AHB-Lite Address Decoding (HSEL)")
+        Component(psram_ctrl, "PSRAM Controller IP", "Gowin IP", "AHB-Lite to PSRAM Bridge")
+
+        Rel(m3, psram_sub, "AHB Expansion", "HADDR, HWDATA, HRDATA, HWRITE, HTRANS, HREADY")
+        Rel(psram_sub, psram_ctrl, "Internal AHB", "hsel, haddr, hwdata, hrdata, hwrite, htrans, hready")
+    }
+}
+
+Component_Ext(psram_chip, "External PSRAM (SiP)", "W955D8MBYA (8MB)", "Co-packaged with GW1NSR-4C")
+
+Rel(psram_ctrl, psram_chip, "PSRAM Bus", "SCLK, CS#, DQ[15:0], ADQ[15:0]")
+
+@enduml


### PR DESCRIPTION
The `m3_ext_psgram` example documentation has been enhanced with a detailed memory mapping table and a C4-PlantUML architecture diagram. The diagram illustrates the AHB-Lite expansion bus signals connecting the Cortex-M3 core to the PSRAM subsystem and the co-packaged W955D8MBYA PSRAM chip. This improvement provides better technical clarity for developers working with the external PSRAM on the Tang Nano 4K.

Fixes #368

---
*PR created automatically by Jules for task [11884048117487582600](https://jules.google.com/task/11884048117487582600) started by @chatelao*