### PR TITLE
Change PSRAM architecture diagram orientation to horizontal

### DIFF
--- a/examples/m3_baremetal/m3_ext_psgram/architecture.puml
+++ b/examples/m3_baremetal/m3_ext_psgram/architecture.puml
@@ -2,6 +2,7 @@
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 
 LAYOUT_WITH_LEGEND()
+left to right direction
 
 title AHB-Lite External PSRAM Architecture (Tang Nano 4K)
 


### PR DESCRIPTION
This change modifies the PlantUML architecture diagram for the `m3_ext_psgram` example to use a horizontal layout (`left to right direction`), aligning it with the project's documentation style. The structural integrity was verified using the repository's verification script.

Fixes #372

---
*PR created automatically by Jules for task [6285012657869057575](https://jules.google.com/task/6285012657869057575) started by @chatelao*