### PR TITLE
Fix PlantUML Diagrams Include and Layout

### DIFF
--- a/examples/m3_baremetal/m3_ext_flash_boot/docs/flash_xip_signals.puml
+++ b/examples/m3_baremetal/m3_ext_flash_boot/docs/flash_xip_signals.puml
@@ -1,5 +1,7 @@
 @startuml flash_xip_signals
-!include https://raw.githubusercontent.com/plantuml-office/C4-PlantUML/master/C4_Component.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_LEFT_RIGHT()
 
 title M3 to External Flash (XIP) Signal Path
 

--- a/examples/m3_baremetal/m3_ext_psgram/architecture.puml
+++ b/examples/m3_baremetal/m3_ext_psgram/architecture.puml
@@ -2,6 +2,7 @@
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 
 LAYOUT_WITH_LEGEND()
+LAYOUT_LEFT_RIGHT()
 
 title AHB-Lite External PSRAM Architecture (Tang Nano 4K)
 

--- a/m3_subsystem.puml
+++ b/m3_subsystem.puml
@@ -1,5 +1,5 @@
 @startuml m3_subsystem
-!include https://raw.githubusercontent.com/plantuml-office/C4-PlantUML/master/C4_Component.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 
 LAYOUT_LEFT_RIGHT()
 


### PR DESCRIPTION
This change fixes the broken PlantUML diagrams by updating the C4-PlantUML include URLs from the legacy `plantuml-office` repository to the current `plantuml-stdlib`. Additionally, it standardizes the diagrams to a horizontal layout using the `LAYOUT_LEFT_RIGHT()` directive, improving readability and compliance with the project's documentation guidelines. Verified that no legacy URLs remain and that the project structure tests pass.

Fixes #373

---
*PR created automatically by Jules for task [11167840644081831689](https://jules.google.com/task/11167840644081831689) started by @chatelao*